### PR TITLE
WebSocket support for streaming events

### DIFF
--- a/example/SeqTail/Properties/launchSettings.json
+++ b/example/SeqTail/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "seq-tail": {
+      "executablePath": "C:\\Development\\nblumhardt\\seq-api\\example\\SeqTail\\bin\\Debug\\net46\\win7-x64\\seq-tail.exe",
+      "commandLineArgs": "http://localhost:5341 --apikey=fSCcBOyOfttZ0kiZFgq"
+    }
+  }
+}

--- a/example/SeqTail/project.json
+++ b/example/SeqTail/project.json
@@ -7,7 +7,10 @@
 
   "dependencies": {
     "Seq.Api": { "target": "project" },
-    "docopt.net": "0.6.1.9"
+    "docopt.net": "0.6.1.9",
+    "Serilog.Formatting.Compact.Reader": "1.0.0-dev-00004",
+    "Serilog.Sinks.Literate": "2.0.0",
+    "System.Reactive": "3.0.0"
   },
 
   "frameworks": {

--- a/example/SeqTail/project.json
+++ b/example/SeqTail/project.json
@@ -6,11 +6,13 @@
   },
 
   "dependencies": {
+    "System.Threading.Tasks": "4.0.11",
     "Seq.Api": { "target": "project" },
     "docopt.net": "0.6.1.9",
-    "Serilog.Formatting.Compact.Reader": "1.0.0-dev-00004",
+    "Serilog.Formatting.Compact.Reader": "1.0.0-dev-00008",
     "Serilog.Sinks.Literate": "2.0.0",
-    "System.Reactive": "3.0.0"
+    "System.Reactive": "3.0.0",
+    "Newtonsoft.Json": "9.0.1"
   },
 
   "frameworks": {

--- a/src/Seq.Api/Api/Streams/ObservableStream.Unsubscriber.cs
+++ b/src/Seq.Api/Api/Streams/ObservableStream.Unsubscriber.cs
@@ -1,0 +1,40 @@
+﻿// Copyright 2016 Datalust; based on code from 
+// Serilog.Sinks.Observable, Copyright 2013-2016 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+using System;
+
+namespace Seq.Api.Streams
+{
+    public partial class ObservableStream<T>
+    {
+        sealed class Unsubscriber : IDisposable
+        {
+            readonly ObservableStream<T> _stream;
+            readonly IObserver<T> _observer;
+
+            public Unsubscriber(ObservableStream<T> sink, IObserver<T> observer)
+            {
+                if (sink == null) throw new ArgumentNullException(nameof(sink));
+                if (observer == null) throw new ArgumentNullException(nameof(observer));
+                _stream = sink;
+                _observer = observer;
+            }
+
+            public void Dispose()
+            {
+                _stream.Unsubscribe(_observer);
+            }
+        }
+    }
+}

--- a/src/Seq.Api/Api/Streams/ObservableStream.cs
+++ b/src/Seq.Api/Api/Streams/ObservableStream.cs
@@ -1,0 +1,201 @@
+﻿// Copyright 2016 Datalust; based on code from Serilog.Sinks.Observable:
+//
+// Copyright 2013-2016 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Net.WebSockets;
+using System.Threading.Tasks;
+using System.IO;
+using System.Text;
+
+namespace Seq.Api.Streams
+{
+    public sealed class ObservableStream<T> : IObservable<T>, IDisposable
+    {
+        // Uses memory barriers for non-blocking reads during Emit, and replaces the
+        // list of observers completely upon subscribe/unsubscribe.
+        // Makes the assumption that list iteration is not
+        // mutating - correct but not guaranteed by the BCL.
+        readonly object _syncRoot = new object();
+        IList<IObserver<T>> _observers = new List<IObserver<T>>();
+        bool _disposed;
+        Task _run;
+
+        readonly ClientWebSocket _socket;
+        readonly Func<TextReader, T> _deserialize;
+
+        sealed class Unsubscriber : IDisposable
+        {
+            readonly ObservableStream<T> _sink;
+            readonly IObserver<T> _observer;
+
+            public Unsubscriber(ObservableStream<T> sink, IObserver<T> observer)
+            {
+                if (sink == null) throw new ArgumentNullException(nameof(sink));
+                if (observer == null) throw new ArgumentNullException(nameof(observer));
+                _sink = sink;
+                _observer = observer;
+            }
+
+            public void Dispose()
+            {
+                _sink.Unsubscribe(_observer);
+            }
+        }
+
+        internal ObservableStream(ClientWebSocket socket, Func<TextReader, T> deserialize)
+        {
+            if (socket == null) throw new ArgumentNullException(nameof(socket));
+            if (deserialize == null) throw new ArgumentNullException(nameof(deserialize));
+
+            _deserialize = deserialize;
+            _socket = socket;
+        }
+
+        public IDisposable Subscribe(IObserver<T> observer)
+        {
+            if (observer == null) throw new ArgumentNullException(nameof(observer));
+
+            lock (_syncRoot)
+            {
+                if (_disposed)
+                    throw new ObjectDisposedException(message: "The observable WebSocket is disposed.", innerException: null);
+
+                var old = _observers;
+                var newObservers = _observers.Concat(new[] { observer }).ToList();
+                while (old != Interlocked.Exchange(ref _observers, newObservers))
+                {
+                    old = _observers;
+                    newObservers = _observers.Concat(new[] { observer }).ToList();
+                }
+
+                if (_run == null)
+                    _run = Task.Run(Receive);
+            }
+
+            return new Unsubscriber(this, observer);
+        }
+
+        void Unsubscribe(IObserver<T> observer)
+        {
+            if (observer == null) throw new ArgumentNullException(nameof(observer));
+
+            lock (_syncRoot)
+            {
+                if (_disposed)
+                    throw new ObjectDisposedException(message: "The observable WebSocket is disposed.", innerException: null);
+
+                var old = _observers;
+                var newObservers = _observers.Except(new[] { observer }).ToList();
+                while (old != Interlocked.Exchange(ref _observers, newObservers))
+                {
+                    old = _observers;
+                    newObservers = _observers.Except(new[] { observer }).ToList();
+                }
+            }
+        }
+
+        async Task Receive()
+        {
+            var buffer = new byte[16 * 1024];
+            var current = new MemoryStream();
+            var reader = new StreamReader(current, new UTF8Encoding(false));
+
+            while (_socket.State == WebSocketState.Open)
+            {
+                var received = await _socket.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
+                if (received.MessageType == WebSocketMessageType.Close)
+                {
+                    await _socket.CloseAsync(WebSocketCloseStatus.NormalClosure, "", CancellationToken.None);
+                }
+                else
+                {
+                    current.Write(buffer, 0, received.Count);
+
+                    if (received.EndOfMessage)
+                    {
+                        current.Position = 0;
+                        var value = _deserialize(reader);
+
+                        current.SetLength(0);
+                        reader.DiscardBufferedData();
+
+                        Emit(value);
+                    }
+                }
+            }
+        }
+
+        void Emit(T value)
+        {
+            if (value == null) throw new ArgumentNullException(nameof(value));
+
+            Interlocked.MemoryBarrier();
+
+            IList<Exception> exceptions = null;
+
+            // Mutations are made by replacing _observers wholesale.
+            // ReSharper disable once InconsistentlySynchronizedField
+            foreach (var observer in _observers)
+            {
+                try
+                {
+                    observer.OnNext(value);
+                }
+                catch (Exception ex)
+                {
+                    if (exceptions == null)
+                        exceptions = new List<Exception>();
+                    exceptions.Add(ex);
+                }
+            }
+
+            // TODO; these need to be caught and propagated.
+            if (exceptions != null)
+                throw new AggregateException("At least one observer failed to accept the event", exceptions);
+        }
+
+        public void Dispose()
+        {
+            lock (_syncRoot)
+            {
+                if (_disposed) return;
+                _disposed = true;
+
+                try
+                {
+                    if (_socket.State == WebSocketState.Open)
+                        _socket.CloseAsync(WebSocketCloseStatus.NormalClosure, "", CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult();
+                }
+                catch { }
+                
+                foreach (var observer in _observers)
+                {
+                    observer.OnCompleted();
+                }
+
+                Interlocked.Exchange(ref _observers, new List<IObserver<T>>());
+
+                if (_run != null)
+                    _run.ConfigureAwait(false).GetAwaiter().GetResult();
+
+                _socket.Dispose();
+            }
+        }
+    }
+}

--- a/src/Seq.Api/Seq.Api.xproj
+++ b/src/Seq.Api/Seq.Api.xproj
@@ -4,16 +4,14 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>d4e037de-9778-4e48-a4a7-e8c1751e637c</ProjectGuid>
-    <RootNamespace>Superpower</RootNamespace>
+    <RootNamespace>Seq</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
   </PropertyGroup>
-
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>

--- a/src/Seq.Api/project.json
+++ b/src/Seq.Api/project.json
@@ -12,7 +12,9 @@
   },
 
   "buildOptions": {
-    "warningsAsErrors": true
+    "warningsAsErrors": true,
+    "xmlDoc": true,
+    "nowarn": ["CS1591"]
   },
 
   "configurations": {
@@ -39,7 +41,8 @@
     "netstandard1.3": {
       "dependencies": {
         "System.Collections.Concurrent": "4.0.12",
-        "System.Net.Http": "4.1.0"
+        "System.Net.Http": "4.1.0",
+        "System.Net.WebSockets.Client": "4.0.0"
       }
     },
     "net4.5": {


### PR DESCRIPTION
Tailing is now **much** simpler:

```csharp
using (var stream =
       await connection.Events.StreamAsync<JObject>(filter: "@EventType = 0xabcd123"))
{
    var subscription = stream
            .Select(jObject => LogEventReader.ReadFromJObject(jObject))
            .Subscribe(evt => Log.Write(evt), () => cancel.Cancel());
 
    cancel.WaitHandle.WaitOne();
    subscription.Dispose();
}
```

Only [compact JSON](https://github.com/serilog/serilog-formatting-compact) event format is currently supported by the API.

Requires Seq 3.4.5-pre or later.