### PR TITLE
Fixes Events.DeleteInSignalAsync()

### DIFF
--- a/src/Seq.Api/Api/Client/SeqApiClient.cs
+++ b/src/Seq.Api/Api/Client/SeqApiClient.cs
@@ -121,6 +121,14 @@ namespace Seq.Api.Client
             new StreamReader(stream).ReadToEnd();
         }
 
+        public async Task<TResponse> DeleteAsync<TEntity, TResponse>(ILinked entity, string link, TEntity content, IDictionary<string, object> parameters = null)
+        {
+            var linkUri = ResolveLink(entity, link, parameters);
+            var request = new HttpRequestMessage(HttpMethod.Delete, linkUri) { Content = MakeJsonContent(content) };
+            var stream = await HttpSendAsync(request).ConfigureAwait(false);
+            return _serializer.Deserialize<TResponse>(new JsonTextReader(new StreamReader(stream)));
+        }
+
         public async Task<ObservableStream<TEntity>> StreamAsync<TEntity>(ILinked entity, string link, IDictionary<string, object> parameters = null)
         {
             return await WebSocketStreamAsync(entity, link, parameters, reader => _serializer.Deserialize<TEntity>(new JsonTextReader(reader)));

--- a/src/Seq.Api/Api/ResourceGroups/ApiResourceGroup.cs
+++ b/src/Seq.Api/Api/ResourceGroups/ApiResourceGroup.cs
@@ -72,5 +72,11 @@ namespace Seq.Api.ResourceGroups
             var group = await LoadGroupAsync().ConfigureAwait(false);
             await Client.DeleteAsync(group, link, content, parameters).ConfigureAwait(false);
         }
+
+        protected async Task<TResponse> GroupDeleteAsync<TEntity, TResponse>(string link, TEntity content, IDictionary<string, object> parameters = null)
+        {
+            var group = await LoadGroupAsync().ConfigureAwait(false);
+            return await Client.DeleteAsync<TEntity, TResponse>(group, link, content, parameters).ConfigureAwait(false);
+        }
     }
 }

--- a/src/Seq.Api/Api/ResourceGroups/EventsResourceGroup.cs
+++ b/src/Seq.Api/Api/ResourceGroups/EventsResourceGroup.cs
@@ -155,7 +155,7 @@ namespace Seq.Api.ResourceGroups
             if (toDateUtc != null) { parameters.Add("toDateUtc", toDateUtc.Value); }
 
             var body = signal ?? new SignalEntity();
-            return await GroupPostAsync<SignalEntity, ResultSetPart>("DeleteInSignal", body, parameters).ConfigureAwait(false);
+            return await GroupDeleteAsync<SignalEntity, ResultSetPart>("DeleteInSignal", body, parameters).ConfigureAwait(false);
         }
 
         /// <summary>


### PR DESCRIPTION
Previous version incorrectly used a POST for this.

Note, `fromDateUtc` and `toDateUtc` generally need to be specified when calling this method to avoid timeouts while scanning-the-world.