### PR TITLE
Use `~` in ToString for unioned signals

### DIFF
--- a/src/Seq.Api/Model/Signals/SignalExpressionPart.cs
+++ b/src/Seq.Api/Model/Signals/SignalExpressionPart.cs
@@ -74,7 +74,7 @@ namespace Seq.Api.Model.Signals
                 return $"{Group(Left)},{Group(Right)}";
 
             if (Kind == SignalExpressionKind.Union)
-                return $"{Group(Left)}+{Group(Right)}";
+                return $"{Group(Left)}~{Group(Right)}";
 
             throw new InvalidOperationException("Invalid signal expression kind.");
         }


### PR DESCRIPTION
So we match the format used in URIs when formatting signal expressions.