### PR TITLE
Ignore un-populated `Signal.IsRestricted`

### DIFF
--- a/src/Seq.Api/Model/Signals/SignalEntity.cs
+++ b/src/Seq.Api/Model/Signals/SignalEntity.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace Seq.Api.Model.Signals
 {
@@ -22,8 +23,9 @@ namespace Seq.Api.Model.Signals
 
         public bool IsWatched { get; set; }
 
-        [Obsolete("This member has been renamed `IsProtected` to better reflect its purpose.")]
         // ReSharper disable once UnusedMember.Global
+        [Obsolete("This member has been renamed `IsProtected` to better reflect its purpose.")]
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public bool? IsRestricted { get; set; }
 
         public bool IsProtected { get; set; }


### PR DESCRIPTION
This property isn't used in Seq v5, but the v4 API won't accept `null` as a valid value.

See: datalust/seqcli#60.