### PR TITLE
Update to the Seq 5.1 API

### DIFF
--- a/example/SeqQuery/SeqQuery.csproj
+++ b/example/SeqQuery/SeqQuery.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netcoreapp1.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.2</TargetFrameworks>
     <AssemblyName>seq-query</AssemblyName>
     <OutputType>Exe</OutputType>
-    <PackageId>SeqQuery</PackageId>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
-    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">1.0.4</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,11 +16,6 @@
 
   <ItemGroup>
     <PackageReference Include="docopt.net" Version="0.6.1.9" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>

--- a/example/SeqTail/SeqTail.csproj
+++ b/example/SeqTail/SeqTail.csproj
@@ -1,13 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netcoreapp1.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.2</TargetFrameworks>
     <AssemblyName>seq-tail</AssemblyName>
     <OutputType>Exe</OutputType>
-    <PackageId>SeqTail</PackageId>
-    <RuntimeIdentifiers>win</RuntimeIdentifiers>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
-    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">1.0.4</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,16 +15,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Threading.Tasks" Version="4.3.0" />
     <PackageReference Include="docopt.net" Version="0.6.1.9" />
     <PackageReference Include="Serilog.Formatting.Compact.Reader" Version="1.0.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="System.Reactive" Version="3.0.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>

--- a/example/SignalCopy/SignalCopy.csproj
+++ b/example/SignalCopy/SignalCopy.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netcoreapp1.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.2</TargetFrameworks>
     <AssemblyName>signal-copy</AssemblyName>
     <OutputType>Exe</OutputType>
-    <PackageId>SignalCopy</PackageId>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
-    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">1.0.4</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,11 +16,6 @@
 
   <ItemGroup>
     <PackageReference Include="docopt.net" Version="0.6.1.9" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>

--- a/src/Seq.Api/Client/SeqApiClient.cs
+++ b/src/Seq.Api/Client/SeqApiClient.cs
@@ -26,7 +26,7 @@ namespace Seq.Api.Client
         // Future versions of Seq may not completely support v1 features, however
         // providing this as an Accept header will ensure what compatibility is available
         // can be utilised.
-        const string SeqApiV6MediaType = "application/vnd.datalust.seq.v6+json";
+        const string SeqApiV7MediaType = "application/vnd.datalust.seq.v7+json";
 
         readonly HttpClient _httpClient;
         readonly CookieContainer _cookies = new CookieContainer();
@@ -181,7 +181,7 @@ namespace Seq.Api.Client
             if (_apiKey != null)
                 request.Headers.Add("X-Seq-ApiKey", _apiKey);
 
-            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(SeqApiV6MediaType));
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(SeqApiV7MediaType));
 
             var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
             var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);

--- a/src/Seq.Api/Model/AppInstances/AppInstanceEntity.cs
+++ b/src/Seq.Api/Model/AppInstances/AppInstanceEntity.cs
@@ -17,21 +17,42 @@ namespace Seq.Api.Model.AppInstances
             Metrics = new AppInstanceMetricsPart();
         }
 
-        public string Title { get; set; }
-        public bool IsManualInputOnly { get; set; }
         public string AppId { get; set; }
+        public string Title { get; set; }
         public Dictionary<string, string> Settings { get; set; }
+
+        /// <summary>
+        /// If <c>true</c>, administrative users may invoke the app manually or through alerts.
+        /// This field is read-only from the API and generally indicates that the app is an input.
+        /// </summary>
+        public bool AcceptPrivilegedInvocation { get; set; }
+
+        /// <summary>
+        /// If <c>true</c>, regular users can manually send events to the app, or use the app
+        /// as the target for alert notifications.
+        /// </summary>
+        public bool AcceptDirectInvocation { get; set; }
         public List<string> InvocationOverridableSettings { get; set; }
-        public TimeSpan? ArrivalWindow { get; set; }
+        public List<AppSettingPart> InvocationOverridableSettingDefinitions { get; set; }
+
+        /// <summary>
+        /// If <c>true</c>, events will be streamed to the app.
+        /// </summary>
+        public bool AcceptStreamedEvents { get; set; }
         public SignalExpressionPart InputSignalExpression { get; set; }
-        public bool DisallowManualInput { get; set; }
-        public int ChannelCapacity { get; set; }
+        public TimeSpan? ArrivalWindow { get; set; }
         public TimeSpan SuppressionTime { get; set; }
         public int EventsPerSuppressionWindow { get; set; }
 
-        public List<AppSettingPart> InvocationOverridableSettingDefinitions { get; set; }
-
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public AppInstanceMetricsPart Metrics { get; set; }
+
+        [Obsolete("Use !AcceptStreamedEvents instead. This field will be removed in Seq 6.0.")]
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public bool? IsManualInputOnly { get; set; }
+
+        [Obsolete("Use !AcceptDirectInvocation instead. This field will be removed in Seq 6.0.")]
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public bool? DisallowManualInput { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Apps/AppEntity.cs
+++ b/src/Seq.Api/Model/Apps/AppEntity.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace Seq.Api.Model.Apps
 {
@@ -8,28 +9,22 @@ namespace Seq.Api.Model.Apps
         public AppEntity()
         {
             Name = "New App";
-#pragma warning disable CS0618 // Type or member is obsolete
-            AssemblyNames = new List<string>();
             AvailableSettings = new List<AppSettingPart>();
-#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         public string Name { get; set; }
 
         public string Description { get; set; }
 
-        [Obsolete("Packages must be installed via a feed.")]
-        public string MainReactorTypeName { get; set; }
-
-        [Obsolete("Packages must be installed via a feed.")]
-        public List<string> AssemblyNames { get; set; }
-
         public List<AppSettingPart> AvailableSettings { get; set; }
 
         public bool AllowReprocessing { get; set; }
 
-        public bool IsReadOnly { get; set; }
-
         public AppPackagePart Package { get; set; }
+
+        /// <summary>
+        /// If <c>true</c>, the app produces an input stream and does not accept events itself.
+        /// </summary>
+        public bool IsInput { get; set; }
     }
 }

--- a/src/Seq.Api/Model/License/LicenseEntity.cs
+++ b/src/Seq.Api/Model/License/LicenseEntity.cs
@@ -8,5 +8,6 @@
         public string StatusDescription { get; set; }
         public bool IsWarning { get; set; }
         public bool CanRenewOnlineNow { get; set; }
+        public int? LicensedUsers { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Monitoring/ChartQueryPart.cs
+++ b/src/Seq.Api/Model/Monitoring/ChartQueryPart.cs
@@ -12,5 +12,8 @@ namespace Seq.Api.Model.Monitoring
         public List<string> GroupBy { get; set; } = new List<string>();
         public MeasurementDisplayStylePart DisplayStyle { get; set; } = new MeasurementDisplayStylePart();
         public List<AlertPart> Alerts { get; set; } = new List<AlertPart>();
+        public string Having { get; set; }
+        public List<string> OrderBy { get; set; } = new List<string>();
+        public int? Limit { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Monitoring/MeasurementDisplayType.cs
+++ b/src/Seq.Api/Model/Monitoring/MeasurementDisplayType.cs
@@ -6,6 +6,7 @@
         Bar,
         Point,
         Value,
-        Pie
+        Pie,
+        Table
     }
 }

--- a/src/Seq.Api/ResourceGroups/RetentionPoliciesResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/RetentionPoliciesResourceGroup.cs
@@ -31,7 +31,7 @@ namespace Seq.Api.ResourceGroups
 
         public async Task<RetentionPolicyEntity> AddAsync(RetentionPolicyEntity entity, CancellationToken cancellationToken = default)
         {
-            return await Client.PostAsync<RetentionPolicyEntity, RetentionPolicyEntity>(entity, "Create", entity, cancellationToken: cancellationToken).ConfigureAwait(false);
+            return await GroupCreateAsync<RetentionPolicyEntity, RetentionPolicyEntity>(entity, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
         public async Task RemoveAsync(RetentionPolicyEntity entity, CancellationToken cancellationToken = default)

--- a/src/Seq.Api/ResourceGroups/SettingsResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/SettingsResourceGroup.cs
@@ -24,11 +24,6 @@ namespace Seq.Api.ResourceGroups
             return await GroupGetAsync<SettingEntity>(name.ToString(), cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<List<SettingEntity>> ListAsync(CancellationToken cancellationToken = default)
-        {
-            return await GroupListAsync<SettingEntity>("Items", cancellationToken: cancellationToken).ConfigureAwait(false);
-        }
-
         public async Task<SettingEntity> TemplateAsync(CancellationToken cancellationToken = default)
         {
             return await GroupGetAsync<SettingEntity>("Template", cancellationToken: cancellationToken).ConfigureAwait(false);

--- a/src/Seq.Api/Seq.Api.csproj
+++ b/src/Seq.Api/Seq.Api.csproj
@@ -1,27 +1,24 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Client library for the Seq HTTP API.</Description>
-    <VersionPrefix>5.0.1</VersionPrefix>
+    <VersionPrefix>5.1.0</VersionPrefix>
     <Authors>Datalust;Contributors</Authors>
-    <TargetFrameworks>netstandard1.3;net46;netstandard2.0</TargetFrameworks>
-    <NoWarn>$(NoWarn);CS1591;CS1573</NoWarn>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Seq.Api</AssemblyName>
     <PackageId>Seq.Api</PackageId>
     <PackageTags>seq</PackageTags>
-    <Copyright>Copyright © 2014-2018 Datalust Pty Ltd and Contributors</Copyright>
-    <PackageIconUrl>https://getseq.net/images/seq-nuget.png</PackageIconUrl>
+    <Copyright>Copyright © 2014-2019 Datalust Pty Ltd and Contributors</Copyright>
+    <PackageIconUrl>https://datalust.co/images/seq-nuget.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/datalust/seq-api</PackageProjectUrl>
     <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
     <RootNamespace>Seq.Api</RootNamespace>
-    <LangVersion>7.1</LangVersion>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="Tavis.UriTemplates" Version="1.1.1" />
-    <PackageReference Include="System.Collections.Concurrent" Version="4.3.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.3" />
   </ItemGroup>
 </Project>

--- a/test/Seq.Api.Tests/Seq.Api.Tests.csproj
+++ b/test/Seq.Api.Tests/Seq.Api.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.2</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 
@@ -15,7 +15,7 @@
     <PackageReference Include="xunit" Version="2.3.1" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>


### PR DESCRIPTION
Includes a bit of sample project modernization.

 * `AppEntity` and `AppInstanceEntity` have been significantly updated for compatibility with custom inputs; some obsolete/unused fields removed
 * `LicenseEntity.LicensedUsers` now included
 * `MeasurementDisplayStyle.Table` now included
 * `ChartQueryPart` now includes `OrderBy`, `Having` and `Limit`