### PR TITLE
Update with the lastest Seq preview features

### DIFF
--- a/example/SignalCopy/Program.cs
+++ b/example/SignalCopy/Program.cs
@@ -94,7 +94,7 @@ Options:
 
                 target.Title = signal.Title;
                 target.Filters = signal.Filters;
-                target.TaggedProperties = signal.TaggedProperties;
+                target.Columns = signal.Columns;
                 target.Description = signal.Description + " (copy)";
 
                 await (target.Id != null ? dstConnection.Signals.UpdateAsync(target) : dstConnection.Signals.AddAsync(target));

--- a/src/Seq.Api/Client/SeqApiClient.cs
+++ b/src/Seq.Api/Client/SeqApiClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Client/SeqApiException.cs
+++ b/src/Seq.Api/Client/SeqApiException.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/AppInstances/AppInstanceEntity.cs
+++ b/src/Seq.Api/Model/AppInstances/AppInstanceEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/AppInstances/AppInstanceMetricsPart.cs
+++ b/src/Seq.Api/Model/AppInstances/AppInstanceMetricsPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Apps/AppEntity.cs
+++ b/src/Seq.Api/Model/Apps/AppEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Apps/AppPackagePart.cs
+++ b/src/Seq.Api/Model/Apps/AppPackagePart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Apps/AppSettingPart.cs
+++ b/src/Seq.Api/Model/Apps/AppSettingPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Backups/BackupEntity.cs
+++ b/src/Seq.Api/Model/Backups/BackupEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Data/QueryExecutionStatisticsPart.cs
+++ b/src/Seq.Api/Model/Data/QueryExecutionStatisticsPart.cs
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 Datalust and contributors. 
+// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,12 +23,12 @@ namespace Seq.Api.Model.Data
         /// The number of events inspected in the course of computing the query result. This will
         /// not include events that could be skipped based on index information or text pre-filtering.
         /// </summary>
-        public long ScannedEventCount { get; set; }
+        public ulong ScannedEventCount { get; set; }
 
         /// <summary>
         /// The number of events that contributed to the query result.
         /// </summary>
-        public long MatchingEventCount { get; set; }
+        public ulong MatchingEventCount { get; set; }
 
         /// <summary>
         /// Whether the query needed to search disk-backed storage.

--- a/src/Seq.Api/Model/Data/QueryResultPart.cs
+++ b/src/Seq.Api/Model/Data/QueryResultPart.cs
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 Datalust and contributors. 
+// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Data/TimeSlicePart.cs
+++ b/src/Seq.Api/Model/Data/TimeSlicePart.cs
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 Datalust and contributors. 
+// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Data/TimeseriesPart.cs
+++ b/src/Seq.Api/Model/Data/TimeseriesPart.cs
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 Datalust and contributors. 
+// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Diagnostics/RunningTaskPart.cs
+++ b/src/Seq.Api/Model/Diagnostics/RunningTaskPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Diagnostics/ServerMetricsEntity.cs
+++ b/src/Seq.Api/Model/Diagnostics/ServerMetricsEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Diagnostics/ServerStatusPart.cs
+++ b/src/Seq.Api/Model/Diagnostics/ServerStatusPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Diagnostics/StatusMessagePart.cs
+++ b/src/Seq.Api/Model/Diagnostics/StatusMessagePart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Entity.cs
+++ b/src/Seq.Api/Model/Entity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Events/DeleteResultPart.cs
+++ b/src/Seq.Api/Model/Events/DeleteResultPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Events/EventEntity.cs
+++ b/src/Seq.Api/Model/Events/EventEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Events/EventInputResultPart.cs
+++ b/src/Seq.Api/Model/Events/EventInputResultPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Events/EventPropertyPart.cs
+++ b/src/Seq.Api/Model/Events/EventPropertyPart.cs
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 Datalust and contributors. 
+// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Events/MessageTemplateTokenPart.cs
+++ b/src/Seq.Api/Model/Events/MessageTemplateTokenPart.cs
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 Datalust and contributors. 
+// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Events/ResultSetPart.cs
+++ b/src/Seq.Api/Model/Events/ResultSetPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Expressions/ExpressionPart.cs
+++ b/src/Seq.Api/Model/Expressions/ExpressionPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Expressions/SqlExpressionPart.cs
+++ b/src/Seq.Api/Model/Expressions/SqlExpressionPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Feeds/NuGetFeedEntity.cs
+++ b/src/Seq.Api/Model/Feeds/NuGetFeedEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/ILinked.cs
+++ b/src/Seq.Api/Model/ILinked.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Inputs/ApiKeyEntity.cs
+++ b/src/Seq.Api/Model/Inputs/ApiKeyEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Inputs/ApiKeyMetricsPart.cs
+++ b/src/Seq.Api/Model/Inputs/ApiKeyMetricsPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Inputs/InputAppliedPropertyPart.cs
+++ b/src/Seq.Api/Model/Inputs/InputAppliedPropertyPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/License/LicenseEntity.cs
+++ b/src/Seq.Api/Model/License/LicenseEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Link.cs
+++ b/src/Seq.Api/Model/Link.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/LinkCollection.cs
+++ b/src/Seq.Api/Model/LinkCollection.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/LogEvents/LogEventLevel.cs
+++ b/src/Seq.Api/Model/LogEvents/LogEventLevel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Monitoring/AlertPart.cs
+++ b/src/Seq.Api/Model/Monitoring/AlertPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Monitoring/AlertStateEntity.cs
+++ b/src/Seq.Api/Model/Monitoring/AlertStateEntity.cs
@@ -1,0 +1,79 @@
+﻿// Copyright Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace Seq.Api.Model.Monitoring
+{
+    /// <summary>
+    /// Describes the state of an active alert.
+    /// </summary>
+    public class AlertStateEntity : Entity
+    {
+        /// <summary>
+        /// The unique id of the alert being described.
+        /// </summary>
+        public string AlertId { get; set; }
+        
+        /// <summary>
+        /// The alert's title.
+        /// </summary>
+        public string Title { get; set; }
+        
+        /// <summary>
+        /// The title of the chart to which the alert is attached.
+        /// </summary>
+        public string ChartTitle { get; set; }
+        
+        /// <summary>
+        /// The title of the dashboards in which the alert is set.
+        /// </summary>
+        public string DashboardTitle { get; set; }
+
+        /// <summary>
+        /// The user id of the user who owns the alert; if <c>null</c>, the alert is shared.
+        /// </summary>
+        public string OwnerId { get; set; }
+
+        /// <summary>
+        /// The notification level associated with the alert.
+        /// </summary>
+        public string Level { get; set; }
+        
+        /// <summary>
+        /// The id of an app instance that will receive notifications when the alert is triggered.
+        /// </summary>
+        public string NotificationAppInstanceId { get; set; }
+
+        /// <summary>
+        /// The time at which the alert was last checked. Not preserved across server restarts.
+        /// </summary>
+        public DateTime? LastCheck { get; set; }
+
+        /// <summary>
+        /// The time at which the alert last triggered a notification. Not preserved across server restarts.
+        /// </summary>
+        public DateTime? LastNotification { get; set; }
+        
+        /// <summary>
+        /// The time until which no further notifications will be sent by the alert.
+        /// </summary>
+        public DateTime? SuppressedUntil { get; set; }
+        
+        /// <summary>
+        /// <c>true</c> if the alert is in the failing state; otherwise, <c>false</c>.
+        /// </summary>
+        public bool IsFailing { get; set; }
+    }
+}

--- a/src/Seq.Api/Model/Monitoring/ChartDisplayStylePart.cs
+++ b/src/Seq.Api/Model/Monitoring/ChartDisplayStylePart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Monitoring/ChartPart.cs
+++ b/src/Seq.Api/Model/Monitoring/ChartPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Monitoring/ChartQueryPart.cs
+++ b/src/Seq.Api/Model/Monitoring/ChartQueryPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Monitoring/DashboardEntity.cs
+++ b/src/Seq.Api/Model/Monitoring/DashboardEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Monitoring/MeasurementDisplayPalette.cs
+++ b/src/Seq.Api/Model/Monitoring/MeasurementDisplayPalette.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Monitoring/MeasurementDisplayStylePart.cs
+++ b/src/Seq.Api/Model/Monitoring/MeasurementDisplayStylePart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Monitoring/MeasurementDisplayType.cs
+++ b/src/Seq.Api/Model/Monitoring/MeasurementDisplayType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Monitoring/MeasurementPart.cs
+++ b/src/Seq.Api/Model/Monitoring/MeasurementPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Permalinks/PermalinkEntity.cs
+++ b/src/Seq.Api/Model/Permalinks/PermalinkEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/ResourceGroup.cs
+++ b/src/Seq.Api/Model/ResourceGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Retention/RetentionPolicyEntity.cs
+++ b/src/Seq.Api/Model/Retention/RetentionPolicyEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Root/RootEntity.cs
+++ b/src/Seq.Api/Model/Root/RootEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Security/Permission.cs
+++ b/src/Seq.Api/Model/Security/Permission.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Security/RoleEntity.cs
+++ b/src/Seq.Api/Model/Security/RoleEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Security/WellKnownRole.cs
+++ b/src/Seq.Api/Model/Security/WellKnownRole.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Settings/InternalErrorReportingSettingsPart.cs
+++ b/src/Seq.Api/Model/Settings/InternalErrorReportingSettingsPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Settings/SettingEntity.cs
+++ b/src/Seq.Api/Model/Settings/SettingEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Settings/SettingName.cs
+++ b/src/Seq.Api/Model/Settings/SettingName.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -109,6 +109,11 @@ namespace Seq.Api.Model.Settings
         /// Seq will stop accepting new events.
         /// </summary>
         MinimumFreeStorageSpace,
+
+        /// <summary>
+        /// A comma-separated list of role ids that will be assigned to new users by default.
+        /// </summary>
+        NewUserRoleIds,
 
         /// <summary>
         /// A comma-separated list of (shared) signal ids that will be included in any new user's

--- a/src/Seq.Api/Model/Shared/DeferredRequestEntity.cs
+++ b/src/Seq.Api/Model/Shared/DeferredRequestEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Shared/ErrorPart.cs
+++ b/src/Seq.Api/Model/Shared/ErrorPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Shared/ResultSetStatus.cs
+++ b/src/Seq.Api/Model/Shared/ResultSetStatus.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Shared/StatisticsPart.cs
+++ b/src/Seq.Api/Model/Shared/StatisticsPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ namespace Seq.Api.Model.Shared
         /// The number of events that were scanned in the search (and were not
         /// able to be excluded based on index information or pre-filtering).
         /// </summary>
-        public long ScannedEventCount { get; set; }
+        public ulong ScannedEventCount { get; set; }
 
         /// <summary>
         /// The id of the last event inspected in the search.

--- a/src/Seq.Api/Model/Signals/SignalColumnPart.cs
+++ b/src/Seq.Api/Model/Signals/SignalColumnPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,14 +15,14 @@
 namespace Seq.Api.Model.Signals
 {
     /// <summary>
-    /// A property that will be displayed as a column when a signal
+    /// An expression that will be displayed as a column when a signal
     /// including it is selected.
     /// </summary>
-    public class TaggedPropertyPart
+    public class SignalColumnPart
     {
         /// <summary>
-        /// The property name.
+        /// The expression to show as a column.
         /// </summary>
-        public string PropertyName { get; set; }
+        public string Expression { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Signals/SignalEntity.cs
+++ b/src/Seq.Api/Model/Signals/SignalEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ namespace Seq.Api.Model.Signals
         {
             Title = "New Signal";
             Filters = new List<SignalFilterPart>();
-            TaggedProperties = new List<TaggedPropertyPart>();
+            Columns = new List<SignalColumnPart>();
         }
 
         /// <summary>
@@ -50,9 +50,9 @@ namespace Seq.Api.Model.Signals
         public List<SignalFilterPart> Filters { get; set; }
 
         /// <summary>
-        /// Properties that show as columns when the signal is selected in the events screen.
+        /// Expressions that show as columns when the signal is selected in the events screen.
         /// </summary>
-        public List<TaggedPropertyPart> TaggedProperties { get; set; }
+        public List<SignalColumnPart> Columns { get; set; }
 
         /// <summary>
         /// Obsolete.

--- a/src/Seq.Api/Model/Signals/SignalExpressionKind.cs
+++ b/src/Seq.Api/Model/Signals/SignalExpressionKind.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Signals/SignalExpressionPart.cs
+++ b/src/Seq.Api/Model/Signals/SignalExpressionPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Signals/SignalFilterPart.cs
+++ b/src/Seq.Api/Model/Signals/SignalFilterPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Signals/SignalGrouping.cs
+++ b/src/Seq.Api/Model/Signals/SignalGrouping.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/SqlQueries/SqlQueryEntity.cs
+++ b/src/Seq.Api/Model/SqlQueries/SqlQueryEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Updates/AvailableUpdateEntity.cs
+++ b/src/Seq.Api/Model/Updates/AvailableUpdateEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Users/AuthProviderInfoPart.cs
+++ b/src/Seq.Api/Model/Users/AuthProviderInfoPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Users/AuthProvidersPart.cs
+++ b/src/Seq.Api/Model/Users/AuthProvidersPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Users/CredentialsPart.cs
+++ b/src/Seq.Api/Model/Users/CredentialsPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Users/SearchHistoryEntity.cs
+++ b/src/Seq.Api/Model/Users/SearchHistoryEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Users/SearchHistoryItemPart.cs
+++ b/src/Seq.Api/Model/Users/SearchHistoryItemPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Users/SearchHistoryItemStatus.cs
+++ b/src/Seq.Api/Model/Users/SearchHistoryItemStatus.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Users/UserEntity.cs
+++ b/src/Seq.Api/Model/Users/UserEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Workspaces/WorkspaceContentPart.cs
+++ b/src/Seq.Api/Model/Workspaces/WorkspaceContentPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Workspaces/WorkspaceEntity.cs
+++ b/src/Seq.Api/Model/Workspaces/WorkspaceEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/ResourceGroups/AlertStateResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/AlertStateResourceGroup.cs
@@ -1,0 +1,65 @@
+﻿// Copyright Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Seq.Api.Model.Monitoring;
+
+namespace Seq.Api.ResourceGroups
+{
+    /// <summary>
+    /// Inspect the current states of alerts being monitored by the server..
+    /// </summary>
+    public class AlertStateResourceGroup : ApiResourceGroup
+    {
+        internal AlertStateResourceGroup(ISeqConnection connection)
+            : base("AlertState", connection)
+        {
+        }
+
+        /// <summary>
+        /// Retrieve the alert state with the given id; throws if the entity does not exist.
+        /// </summary>
+        /// <param name="id">The id of the alert state.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The alert state.</returns>
+        public async Task<AlertStateEntity> FindAsync(string id, CancellationToken cancellationToken = default)
+        {
+            if (id == null) throw new ArgumentNullException(nameof(id));
+            return await GroupGetAsync<AlertStateEntity>("Item", new Dictionary<string, object> { { "id", id } }, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Retrieve the states of all alerts being monitored by the server.
+        /// </summary>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>A list containing all current alert states.</returns>
+        public async Task<List<AlertStateEntity>> ListAsync(CancellationToken cancellationToken = default)
+        {
+            return await GroupListAsync<AlertStateEntity>("Items", null, cancellationToken).ConfigureAwait(false);
+        }
+    
+        /// <summary>
+        /// Remove an alert state; this will remove the corresponding alert.
+        /// </summary>
+        /// <param name="entity">The alert state to remove</param>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        public async Task RemoveAsync(AlertStateEntity entity, CancellationToken cancellationToken = default)
+        {
+            await Client.DeleteAsync(entity, "Self", entity, cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Seq.Api/ResourceGroups/ApiKeysResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/ApiKeysResourceGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/ResourceGroups/ApiResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/ApiResourceGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/ResourceGroups/AppInstancesResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/AppInstancesResourceGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/ResourceGroups/AppInstancesResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/AppInstancesResourceGroup.cs
@@ -78,7 +78,7 @@ namespace Seq.Api.ResourceGroups
         public async Task<AppInstanceEntity> AddAsync(AppInstanceEntity entity, bool runOnExisting = false, CancellationToken cancellationToken = default)
         {
             if (entity == null) throw new ArgumentNullException(nameof(entity));
-            return await Client.PostAsync<AppInstanceEntity, AppInstanceEntity>(entity, "Create", entity, new Dictionary<string, object> { { "runOnExisting", runOnExisting } }, cancellationToken)
+            return await GroupCreateAsync<AppInstanceEntity, AppInstanceEntity>(entity, new Dictionary<string, object> { { "runOnExisting", runOnExisting } }, cancellationToken)
                 .ConfigureAwait(false);
         }
 

--- a/src/Seq.Api/ResourceGroups/AppsResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/AppsResourceGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -71,7 +71,7 @@ namespace Seq.Api.ResourceGroups
         /// <returns>The app, with server-allocated properties such as <see cref="Entity.Id"/> initialized.</returns>
         public async Task<AppEntity> AddAsync(AppEntity entity, CancellationToken cancellationToken = default)
         {
-            return await Client.PostAsync<AppEntity, AppEntity>(entity, "Create", entity, cancellationToken: cancellationToken).ConfigureAwait(false);
+            return await GroupCreateAsync<AppEntity, AppEntity>(entity, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/Seq.Api/ResourceGroups/BackupsResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/BackupsResourceGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/ResourceGroups/DashboardsResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/DashboardsResourceGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/ResourceGroups/DataResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/DataResourceGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/ResourceGroups/DiagnosticsResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/DiagnosticsResourceGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/ResourceGroups/EventsResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/EventsResourceGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/ResourceGroups/ExpressionsResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/ExpressionsResourceGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/ResourceGroups/FeedsResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/FeedsResourceGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -71,7 +71,7 @@ namespace Seq.Api.ResourceGroups
         /// <returns>The feed, with server-allocated properties such as <see cref="Entity.Id"/> initialized.</returns>
         public async Task<NuGetFeedEntity> AddAsync(NuGetFeedEntity entity, CancellationToken cancellationToken = default)
         {
-            return await Client.PostAsync<NuGetFeedEntity, NuGetFeedEntity>(entity, "Create", entity, cancellationToken: cancellationToken).ConfigureAwait(false);
+            return await GroupCreateAsync<NuGetFeedEntity, NuGetFeedEntity>(entity, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/Seq.Api/ResourceGroups/ISeqConnection.cs
+++ b/src/Seq.Api/ResourceGroups/ISeqConnection.cs
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 Datalust and contributors. 
+// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/ResourceGroups/LicensesResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/LicensesResourceGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/ResourceGroups/PermalinksResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/PermalinksResourceGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/ResourceGroups/RetentionPoliciesResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/RetentionPoliciesResourceGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/ResourceGroups/RolesResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/RolesResourceGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/ResourceGroups/SettingsResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/SettingsResourceGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -67,20 +67,22 @@ namespace Seq.Api.ResourceGroups
         /// <summary>
         /// Get internal error reporting settings.
         /// </summary>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
         /// <returns>Internal error reporting settings.</returns>
-        public async Task<InternalErrorReportingSettingsPart> GetInternalErrorReportingAsync()
+        public async Task<InternalErrorReportingSettingsPart> GetInternalErrorReportingAsync(CancellationToken cancellationToken = default)
         {
-            return await GroupGetAsync<InternalErrorReportingSettingsPart>("InternalErrorReporting").ConfigureAwait(false);
+            return await GroupGetAsync<InternalErrorReportingSettingsPart>("InternalErrorReporting", cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
         /// Update internal error reporting settings.
         /// </summary>
         /// <param name="internalErrorReporting">New internal error reporting settings.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
         /// <returns>A task indicating completion.</returns>
-        public async Task UpdateInternalErrorReportingAsync(InternalErrorReportingSettingsPart internalErrorReporting)
+        public async Task UpdateInternalErrorReportingAsync(InternalErrorReportingSettingsPart internalErrorReporting, CancellationToken cancellationToken = default)
         {
-            await GroupPutAsync("InternalErrorReporting", internalErrorReporting).ConfigureAwait(false);
+            await GroupPutAsync("InternalErrorReporting", internalErrorReporting, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/Seq.Api/ResourceGroups/SignalsResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/SignalsResourceGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/ResourceGroups/SqlQueriesResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/SqlQueriesResourceGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/ResourceGroups/UpdatesResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/UpdatesResourceGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/ResourceGroups/UsersResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/UsersResourceGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -83,7 +83,7 @@ namespace Seq.Api.ResourceGroups
         /// <returns>The user, with server-allocated properties such as <see cref="Entity.Id"/> initialized.</returns>
         public async Task<UserEntity> AddAsync(UserEntity entity, CancellationToken cancellationToken = default)
         {
-            return await Client.PostAsync<UserEntity, UserEntity>(entity, "Create", entity, cancellationToken: cancellationToken).ConfigureAwait(false);
+            return await GroupCreateAsync<UserEntity, UserEntity>(entity, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/Seq.Api/ResourceGroups/WorkspacesResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/WorkspacesResourceGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Seq.Api.csproj
+++ b/src/Seq.Api/Seq.Api.csproj
@@ -1,20 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Client library for the Seq HTTP API.</Description>
-    <VersionPrefix>5.1.3</VersionPrefix>
+    <VersionPrefix>2020.1.0</VersionPrefix>
     <Authors>Datalust;Contributors</Authors>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>seq</PackageTags>
-    <Copyright>Copyright © 2014-2019 Datalust Pty Ltd and Contributors</Copyright>
+    <Copyright>Copyright © Datalust Pty Ltd and Contributors</Copyright>
     <PackageIconUrl>https://datalust.co/images/seq-nuget.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/datalust/seq-api</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="Tavis.UriTemplates" Version="1.1.1" />
   </ItemGroup>
 </Project>

--- a/src/Seq.Api/SeqConnection.cs
+++ b/src/Seq.Api/SeqConnection.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -75,6 +75,12 @@ namespace Seq.Api
         /// </summary>
         public SeqApiClient Client { get; }
 
+        /// <summary>
+        /// List and administratively remove active alerts. To create/edit/remove alerts in normal
+        /// circumstances, use <see cref="Dashboards"/>.
+        /// </summary>
+        public AlertStateResourceGroup AlertState => new AlertStateResourceGroup(this);
+ 
         /// <summary>
         /// Perform operations on API keys.
         /// </summary>
@@ -181,7 +187,7 @@ namespace Seq.Api
         /// </summary>
         /// <param name="timeout">The maximum amount of time to retry until giving up.</param>
         /// <returns>A task that will complete if the API could be reached, or fault otherwise.</returns>
-        public async Task EnsureConnected(TimeSpan timeout)
+        public async Task EnsureConnectedAsync(TimeSpan timeout)
         {
             var started = DateTime.UtcNow;
             // Fractional milliseconds are lost here, but that's fine.

--- a/src/Seq.Api/Serialization/LinkCollectionConverter.cs
+++ b/src/Seq.Api/Serialization/LinkCollectionConverter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Streams/ObservableStream.Unsubscriber.cs
+++ b/src/Seq.Api/Streams/ObservableStream.Unsubscriber.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2016 Datalust; based on code from 
+﻿// Copyright © Datalust; based on code from 
 // Serilog.Sinks.Observable, Copyright 2013-2016 Serilog Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
This makes two minor breaking changes:

 * `Signal.TaggedProperties` becomes `Signal.Columns`
 * `SeqConnection.EnsureConnected()` becomes `EnsureConnectedAsync()`, consistent with the other APIs in this project

Also:

 * Version prefix becomes `2020.1`, in step with the versioning we'll use for the upcoming Seq release
 * Adds `AlertStateEntity` and `SeqConnection.AlertStates`
 * Adds `SettingName.NewUserRoleIds`
 * Allows app instances, feeds, and users to be created without first calling `TemplateAsync()`
 * Fix websocket shutdown on recent .NET Core versions
