### PR TITLE
Update to the latest Seq 2020.1 API version (breaking changes, here!)

### DIFF
--- a/src/Seq.Api/Client/SeqApiClient.cs
+++ b/src/Seq.Api/Client/SeqApiClient.cs
@@ -42,7 +42,7 @@ namespace Seq.Api.Client
         // Future versions of Seq may not completely support v1 features, however
         // providing this as an Accept header will ensure what compatibility is available
         // can be utilized.
-        const string SeqApiV7MediaType = "application/vnd.datalust.seq.v7+json";
+        const string SeqApiV8MediaType = "application/vnd.datalust.seq.v8+json";
 
         readonly CookieContainer _cookies = new CookieContainer();
         readonly JsonSerializer _serializer = JsonSerializer.Create(
@@ -89,7 +89,7 @@ namespace Seq.Api.Client
                 baseAddress += "/";
 
             HttpClient = new HttpClient(handler) { BaseAddress = new Uri(baseAddress) };
-            HttpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(SeqApiV7MediaType));
+            HttpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(SeqApiV8MediaType));
 
             if (_apiKey != null)
                 HttpClient.DefaultRequestHeaders.Add("X-Seq-ApiKey", _apiKey);

--- a/src/Seq.Api/Model/AppInstances/AppInstanceEntity.cs
+++ b/src/Seq.Api/Model/AppInstances/AppInstanceEntity.cs
@@ -16,6 +16,7 @@ using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using Seq.Api.Model.Apps;
+using Seq.Api.Model.Inputs;
 using Seq.Api.Model.Signals;
 using Seq.Api.ResourceGroups;
 
@@ -38,7 +39,11 @@ namespace Seq.Api.Model.AppInstances
             InvocationOverridableSettings = new List<string>();
             InvocationOverridableSettingDefinitions = new List<AppSettingPart>();
             EventsPerSuppressionWindow = 1;
-            Metrics = new AppInstanceMetricsPart();
+            ProcessMetrics = new AppInstanceProcessMetricsPart();
+            InputSettings = new InputSettingsPart();
+            InputMetrics = new InputMetricsPart();
+            DiagnosticInputMetrics = new InputMetricsPart();
+            OutputMetrics = new AppInstanceOutputMetricsPart();
         }
 
         /// <summary>
@@ -90,7 +95,7 @@ namespace Seq.Api.Model.AppInstances
         /// The signal expression describing which events will be sent to the app; if <c>null</c>,
         /// all events will reach the app.
         /// </summary>
-        public SignalExpressionPart InputSignalExpression { get; set; }
+        public SignalExpressionPart StreamedSignalExpression { get; set; }
 
         /// <summary>
         /// If a value is specified, events will be buffered to disk and sorted by timestamp-order
@@ -113,22 +118,46 @@ namespace Seq.Api.Model.AppInstances
         public int EventsPerSuppressionWindow { get; set; }
 
         /// <summary>
-        /// Metrics describing the state and activity of the app.
+        /// Settings that control how events are ingested through the app.
         /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public AppInstanceMetricsPart Metrics { get; set; }
+        public InputSettingsPart InputSettings { get; set; }
 
+        /// <summary>
+        /// Metrics describing the state and activity of the app process.
+        /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public AppInstanceProcessMetricsPart ProcessMetrics { get; set; }
+        
+        /// <summary>
+        /// Information about ingestion activity through this app.
+        /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public InputMetricsPart InputMetrics { get; set; }
+
+        /// <summary>
+        /// Information about the app's diagnostic input.
+        /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public InputMetricsPart DiagnosticInputMetrics { get; set; }
+
+        /// <summary>
+        /// Information about events output through the app.
+        /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public AppInstanceOutputMetricsPart OutputMetrics { get; set; }
+        
         /// <summary>
         /// Obsolete.
         /// </summary>
-        [Obsolete("Use !AcceptStreamedEvents instead. This field will be removed in Seq 6.0.")]
+        [Obsolete("Use !AcceptStreamedEvents instead.")]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public bool? IsManualInputOnly { get; set; }
 
         /// <summary>
         /// Obsolete.
         /// </summary>
-        [Obsolete("Use !AcceptDirectInvocation instead. This field will be removed in Seq 6.0.")]
+        [Obsolete("Use !AcceptDirectInvocation instead.")]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public bool? DisallowManualInput { get; set; }
     }

--- a/src/Seq.Api/Model/AppInstances/AppInstanceOutputMetricsPart.cs
+++ b/src/Seq.Api/Model/AppInstances/AppInstanceOutputMetricsPart.cs
@@ -1,0 +1,15 @@
+namespace Seq.Api.Model.AppInstances
+{
+    /// <summary>
+    /// Describes the events reaching being output from Seq through the app.
+    /// </summary>
+    public class AppInstanceOutputMetricsPart
+    {
+        /// <summary>
+        /// The number of events per minute sent from Seq to the app. Includes streamed events (if enabled),
+        /// manual invocations, and alert notifications. There may be some delay between dispatching an event, and
+        /// it being processed by the app.
+        /// </summary>
+        public int DispatchedEventsPerMinute { get; set; }
+    }
+}

--- a/src/Seq.Api/Model/AppInstances/AppInstanceProcessMetricsPart.cs
+++ b/src/Seq.Api/Model/AppInstances/AppInstanceProcessMetricsPart.cs
@@ -15,25 +15,14 @@
 namespace Seq.Api.Model.AppInstances
 {
     /// <summary>
-    /// Metrics describing an <see cref="AppInstanceEntity"/>.
+    /// Metrics describing the running server-side process for an <see cref="AppInstanceEntity"/>.
     /// </summary>
-    public class AppInstanceMetricsPart
+    public class AppInstanceProcessMetricsPart
     {
-        /// <summary>
-        /// The number of events that reached the app in the past minute.
-        /// </summary>
-        public int ReceivedEventsPerMinute { get; set; }
-
-        /// <summary>
-        /// The number of diagnostic events raised by the app in the past minute.
-        /// </summary>
-        /// <remarks>This does not include the events received by an input app.</remarks>
-        public int EmittedEventsPerMinute { get; set; }
-
         /// <summary>
         /// The size, in bytes, of the app process working set.
         /// </summary>
-        public long ProcessWorkingSetBytes { get; set; }
+        public long WorkingSetBytes { get; set; }
 
         /// <summary>
         /// If the app process is running, <c>true</c>; otherwise, <c>false</c>.

--- a/src/Seq.Api/Model/Diagnostics/MeasurementTimeseriesPart.cs
+++ b/src/Seq.Api/Model/Diagnostics/MeasurementTimeseriesPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © Datalust and contributors. 
+// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,29 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace Seq.Api.Model.Inputs
+using System;
+
+namespace Seq.Api.Model.Diagnostics
 {
     /// <summary>
-    /// Information about ingestion activity using an API key.
+    /// A histogram presenting a measurement taken at equal intervals.
     /// </summary>
-    public class ApiKeyMetricsPart
+    public class MeasurementTimeseriesPart
     {
         /// <summary>
-        /// The number of events that arrived at the server tagged with this
-        /// key in the past minute.
+        /// The point in time from which measurement begins.
         /// </summary>
-        public int ArrivalsPerMinute { get; set; }
-
-        /// <summary>
-        /// The number of events that ingested by the server tagged with this
-        /// key in the past minute.
-        /// </summary>
-        public int InfluxPerMinute { get; set; }
+        public DateTime MeasuredFrom { get; set; }
         
         /// <summary>
-        /// The raw JSON bytes (approximate) tagged with this API key that were ingested
-        /// by the server in the past minute.
+        /// The interval at which the measurement is taken.
         /// </summary>
-        public long IngestedBytesPerMinute { get; set; }
+        public ulong MeasurementIntervalMilliseconds { get; set; }
+        
+        /// <summary>
+        /// The measurements at each interval, beginning with <see cref="MeasuredFrom"/>.
+        /// </summary>
+        public long[] Measurements { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Diagnostics/ServerMetricsEntity.cs
+++ b/src/Seq.Api/Model/Diagnostics/ServerMetricsEntity.cs
@@ -27,7 +27,6 @@ namespace Seq.Api.Model.Diagnostics
         /// </summary>
         public ServerMetricsEntity()
         {
-            RunningTasks = new List<RunningTaskPart>();
         }
 
         /// <summary>
@@ -41,16 +40,6 @@ namespace Seq.Api.Model.Diagnostics
         public int EventStoreEventsCached { get; set; }
 
         /// <summary>
-        /// The oldest on-disk extent currently stored.
-        /// </summary>
-        public DateTime? EventStoreFirstExtentRangeStartUtc { get; set; }
-
-        /// <summary>
-        /// The most recent on-disk extent currently stored.
-        /// </summary>
-        public DateTime? EventStoreLastExtentRangeEndUtc { get; set; }
-
-        /// <summary>
         /// Bytes of free space remaining on the disk used for event storage.
         /// </summary>
         public long EventStoreDiskRemainingBytes { get; set; }
@@ -58,27 +47,27 @@ namespace Seq.Api.Model.Diagnostics
         /// <summary>
         /// The number of events that arrived at the ingestion endpoint in the past minute.
         /// </summary>
-        public int EndpointArrivalsPerMinute { get; set; }
+        public int InputArrivedEventsPerMinute { get; set; }
 
         /// <summary>
         /// The number of events ingested in the past minute.
         /// </summary>
-        public int EndpointInfluxPerMinute { get; set; }
+        public int InputIngestedEventsPerMinute { get; set; }
 
         /// <summary>
         /// The number of bytes of raw JSON event data ingested in the past minute (approximate).
         /// </summary>
-        public long EndpointIngestedBytesPerMinute { get; set; }
+        public long InputIngestedBytesPerMinute { get; set; }
 
         /// <summary>
         /// The number of invalid event payloads seen in the past minute.
         /// </summary>
-        public int EndpointInvalidPayloadsPerMinute { get; set; }
+        public int InvalidPayloadsPerMinute { get; set; }
 
         /// <summary>
         /// The number of unauthorized event payloads seen in the past minute.
         /// </summary>
-        public int EndpointUnauthorizedPayloadsPerMinute { get; set; }
+        public int HttpUnauthorizedPayloadsPerMinute { get; set; }
 
         /// <summary>
         /// The length of time for which the Seq server process has been running.
@@ -96,24 +85,9 @@ namespace Seq.Api.Model.Diagnostics
         public int ProcessThreads { get; set; }
 
         /// <summary>
-        /// The number of thread pool user threads available.
-        /// </summary>
-        public int ProcessThreadPoolUserThreadsAvailable { get; set; }
-
-        /// <summary>
-        /// The number of async I/O thread pool threads available.
-        /// </summary>
-        public int ProcessThreadPoolIocpThreadsAvailable { get; set; }
-
-        /// <summary>
         /// The proportion of system physical memory that is currently allocated.
         /// </summary>
         public double SystemMemoryUtilization { get; set; }
-
-        /// <summary>
-        /// Tasks running in the Seq server.
-        /// </summary>
-        public List<RunningTaskPart> RunningTasks { get; set; }
 
         /// <summary>
         /// The number of SQL-style queries executed in the past minute.
@@ -129,10 +103,5 @@ namespace Seq.Api.Model.Diagnostics
         /// The number of cached SQL query time slices invalidated in the past minute.
         /// </summary>
         public int QueryCacheInvalidationsPerMinute { get; set; }
-
-        /// <summary>
-        /// The number of active sessions reading from or writing to Seq's internal metadata store.
-        /// </summary>
-        public int DocumentStoreActiveSessions { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Entity.cs
+++ b/src/Seq.Api/Model/Entity.cs
@@ -12,6 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
 namespace Seq.Api.Model
 {
     /// <summary>
@@ -41,5 +46,12 @@ namespace Seq.Api.Model
         /// was instantiated locally and not received from the API.
         /// </summary>
         public LinkCollection Links { get; set; }
+
+        /// <summary>
+        /// Facilitates backwards compatibility in the Seq server. Should not be used by consumers/clients.
+        /// </summary>
+        [JsonExtensionData, JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [Obsolete("Facilitates backwards compatibility in the Seq server. Should not be used by consumers/clients.")]
+        public Dictionary<string, JToken> ExtensionData { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Inputs/ApiKeyEntity.cs
+++ b/src/Seq.Api/Model/Inputs/ApiKeyEntity.cs
@@ -14,9 +14,7 @@
 
 using System.Collections.Generic;
 using Newtonsoft.Json;
-using Seq.Api.Model.LogEvents;
 using Seq.Api.Model.Security;
-using Seq.Api.Model.Signals;
 
 namespace Seq.Api.Model.Inputs
 {
@@ -33,10 +31,10 @@ namespace Seq.Api.Model.Inputs
         public string Title { get; set; }
 
         /// <summary>
-        /// The API key token. API keys generated for versions of Seq prior to 5.0 will expose this value. From 5.0 onwards,
-        /// <see cref="Token"/> can be specified explicitly when creating an API key, but is not readable once the API key is created.
-        /// Leaving the token blank will cause the server to generate a cryptographically random API key token. After creation, the first
-        /// few characters of the token will be readable from <see cref="TokenPrefix"/>, but because only a cryptographically-secure
+        /// The API key token. <see cref="Token"/> can be specified explicitly when creating an API key, but is not
+        /// readable once the API key is created. Leaving the token blank will cause the server to generate a
+        /// cryptographically random API key token. After creation, the first few (additional, redundant) characters
+        /// of the token will be readable from <see cref="TokenPrefix"/>, but because only a cryptographically-secure
         /// hash of the token is stored internally, the token itself cannot be retrieved.
         /// </summary>
         public string Token { get; set; }
@@ -47,31 +45,12 @@ namespace Seq.Api.Model.Inputs
         public string TokenPrefix { get; set; }
 
         /// <summary>
-        /// Properties that will be automatically added to all events ingested using the key. These will override any properties with
-        /// the same names already present on the event.
+        /// Settings that control how events are ingested through the API key.
         /// </summary>
-        public List<InputAppliedPropertyPart> AppliedProperties { get; set; } = new List<InputAppliedPropertyPart>();
+        public InputSettingsPart InputSettings { get; set; } = new InputSettingsPart();
 
         /// <summary>
-        /// A filter that selects events to ingest. If <c>null</c>, all events received using the key will be ingested.
-        /// </summary>
-        public SignalFilterPart InputFilter { get; set; } = new SignalFilterPart();
-
-        /// <summary>
-        /// A minimum level at which events received using the key will be ingested. The level hierarchy understood by Seq is fuzzy
-        /// enough to handle most common leveling schemes. This value will be provided to callers so that they can dynamically
-        /// filter events client-side, if supported.
-        /// </summary>
-        public LogEventLevel? MinimumLevel { get; set; }
-
-        /// <summary>
-        /// If <c>true</c>, timestamps already present on the events will be ignored, and server timestamps used instead. This is not
-        /// recommended for most use cases.
-        /// </summary>
-        public bool UseServerTimestamps { get; set; }
-
-        /// <summary>
-        /// If <c>true</c>, the key is the built-in (tokenless) API key.
+        /// If <c>true</c>, the key is the built-in (tokenless) API key representing unauthenticated HTTP ingestion.
         /// </summary>
         public bool IsDefault { get; set; }
 
@@ -90,6 +69,6 @@ namespace Seq.Api.Model.Inputs
         /// Information about the ingestion activity using this API key.
         /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public ApiKeyMetricsPart Metrics { get; set; } = new ApiKeyMetricsPart();
+        public InputMetricsPart InputMetrics { get; set; } = new InputMetricsPart();
     }
 }

--- a/src/Seq.Api/Model/Inputs/InputMetricsPart.cs
+++ b/src/Seq.Api/Model/Inputs/InputMetricsPart.cs
@@ -1,0 +1,44 @@
+﻿// Copyright © Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Seq.Api.Model.Inputs
+{
+    /// <summary>
+    /// Information about ingestion activity using an API key.
+    /// </summary>
+    public class InputMetricsPart
+    {
+        /// <summary>
+        /// The number of events that arrived at the server from this input in the past minute.
+        /// </summary>
+        public int ArrivedEventsPerMinute { get; set; }
+
+        /// <summary>
+        /// The number of events that ingested by the server from this input in the past minute.
+        /// </summary>
+        public int IngestedEventsPerMinute { get; set; }
+        
+        /// <summary>
+        /// The raw JSON bytes (approximate) from this input that were ingested
+        /// by the server in the past minute.
+        /// </summary>
+        public long IngestedBytesPerMinute { get; set; }
+        
+        /// <summary>
+        /// The number of invalid payloads reaching this input in the past minute. Invalid payloads includes malformed
+        /// and oversized JSON event bodies, as well as malformed or oversized batches.
+        /// </summary>
+        public long InvalidPayloadsPerMinute { get; set; }
+    }
+}

--- a/src/Seq.Api/Model/Inputs/InputSettingsPart.cs
+++ b/src/Seq.Api/Model/Inputs/InputSettingsPart.cs
@@ -1,0 +1,51 @@
+// Copyright © Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using Seq.Api.Model.LogEvents;
+using Seq.Api.Model.Shared;
+using Seq.Api.Model.Signals;
+
+namespace Seq.Api.Model.Inputs
+{
+    /// <summary>
+    /// Settings carried by API keys, (input) app instances, and other inputs.
+    /// </summary>
+    public class InputSettingsPart
+    {
+        /// <summary>
+        /// Properties that will be automatically added to all events ingested using the key. These will override any properties with
+        /// the same names already present on the event.
+        /// </summary>
+        public List<InputAppliedPropertyPart> AppliedProperties { get; set; } = new List<InputAppliedPropertyPart>();
+
+        /// <summary>
+        /// A filter that selects events to ingest. If <c>null</c>, all events received using the key will be ingested.
+        /// </summary>
+        public DescriptiveFilterPart Filter { get; set; } = new DescriptiveFilterPart();
+
+        /// <summary>
+        /// A minimum level at which events received using the key will be ingested. The level hierarchy understood by Seq is fuzzy
+        /// enough to handle most common leveling schemes. This value will be provided to callers so that they can dynamically
+        /// filter events client-side, if supported.
+        /// </summary>
+        public LogEventLevel? MinimumLevel { get; set; }
+
+        /// <summary>
+        /// If <c>true</c>, timestamps already present on the events will be ignored, and server timestamps used instead. This is not
+        /// recommended for most use cases.
+        /// </summary>
+        public bool UseServerTimestamps { get; set; }
+    }
+}

--- a/src/Seq.Api/Model/Settings/SettingName.cs
+++ b/src/Seq.Api/Model/Settings/SettingName.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using Seq.Api.Model.Apps;
 using Seq.Api.Model.Updates;
 using Seq.Api.ResourceGroups;
@@ -25,6 +26,12 @@ namespace Seq.Api.Model.Settings
     public enum SettingName
     {
         /// <summary>
+        /// The authentication provider to use. Allowed values are <c>null</c> (local username/password),
+        /// <c>"Active Directory"</c>, <c>"Azure Active Directory"</c> and <c>"OpenID Connect"</c>.
+        /// </summary>
+        AuthenticationProvider,
+        
+        /// <summary>
         /// The name of an Active Directory group within which users will be automatically
         /// be granted user access to Seq.
         /// </summary>
@@ -34,8 +41,21 @@ namespace Seq.Api.Model.Settings
         /// If <c>true</c>, Azure Active Directory accounts in the configured tenant will
         /// be automatically granted user access to Seq.
         /// </summary>
+        [Obsolete("Use `AutomaticallyProvisionAuthenticatedUsers`.", error: true)]
         AutomaticallyGrantUserAccessToADAccounts,
+        
+        /// <summary>
+        /// If <c>true</c>, users authenticated with the configured authentication provider
+        /// be automatically granted default user access to Seq.
+        /// </summary>
+        AutomaticallyProvisionAuthenticatedUsers,
 
+        /// <summary>
+        /// The AAD authority. The default is <c>login.windows.net</c>; government cloud users may
+        /// require <c>login.microsoftonline.us</c> or similar.
+        /// </summary>
+        AzureADAuthority,
+        
         /// <summary>
         /// The Azure Active Directory client id.
         /// </summary>
@@ -87,17 +107,13 @@ namespace Seq.Api.Model.Settings
         /// <summary>
         /// If <c>true</c>, the server supports Active Directory authentication.
         /// </summary>
+        [Obsolete("Set `AuthenticationProvider` to \"Active Directory\" to enable.", error: true)]
         IsActiveDirectoryAuthentication,
 
         /// <summary>
         /// If <c>true</c>, the server has authentication enabled.
         /// </summary>
         IsAuthenticationEnabled,
-
-        /// <summary>
-        /// Obsolete.
-        /// </summary>
-        LazilyFlushEventWrites,
 
         /// <summary>
         /// Tracks whether an admin user has dismissed the master key backup warning.
@@ -133,6 +149,28 @@ namespace Seq.Api.Model.Settings
         /// </summary>
         NewUserShowDashboardIds,
 
+        /// <summary>
+        /// If using OpenID Connect authentication, the URL of the authorization endpoint. For example,
+        /// <c>https://example.com</c>.
+        /// </summary>
+        OpenIdConnectAuthority,
+        
+        /// <summary>
+        /// If using OpenID Connect, the client id assigned to Seq in the provider.
+        /// </summary>
+        OpenIdConnectClientId,
+        
+        /// <summary>
+        /// If using OpenID Connect, the client secret assigned to Seq in the provider.
+        /// </summary>
+        OpenIdConnectClientSecret,
+
+        /// <summary>
+        /// If using OpenID Connect, the scopes Seq will request when authorizing the client, as a comma-separated
+        /// list. For example, <c>openid, profile, email</c>.
+        /// </summary>
+        OpenIdConnectScopes,
+    
         /// <summary>
         /// If <c>true</c>, ingestion requests incoming via HTTP must be authenticated using an API key or
         /// logged-in user session. Only effective when <see cref="IsAuthenticationEnabled"/> is <c>true</c>.

--- a/src/Seq.Api/Model/Shared/DescriptiveFilterPart.cs
+++ b/src/Seq.Api/Model/Shared/DescriptiveFilterPart.cs
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace Seq.Api.Model.Signals
+namespace Seq.Api.Model.Shared
 {
     /// <summary>
-    /// An individual filter incorporated within a signal.
+    /// An expression-based filter that carries additional descriptive information.
     /// </summary>
-    public class SignalFilterPart
+    public class DescriptiveFilterPart
     {
         /// <summary>
         /// A friendly, human-readable description of the filter.

--- a/src/Seq.Api/Model/Signals/SignalEntity.cs
+++ b/src/Seq.Api/Model/Signals/SignalEntity.cs
@@ -16,6 +16,7 @@ using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using Seq.Api.Model.Security;
+using Seq.Api.Model.Shared;
 
 namespace Seq.Api.Model.Signals
 {
@@ -30,7 +31,7 @@ namespace Seq.Api.Model.Signals
         public SignalEntity()
         {
             Title = "New Signal";
-            Filters = new List<SignalFilterPart>();
+            Filters = new List<DescriptiveFilterPart>();
             Columns = new List<SignalColumnPart>();
         }
 
@@ -47,7 +48,7 @@ namespace Seq.Api.Model.Signals
         /// <summary>
         /// Filters that are combined (using the <c>and</c> operator) to identify events matching the filter.
         /// </summary>
-        public List<SignalFilterPart> Filters { get; set; }
+        public List<DescriptiveFilterPart> Filters { get; set; }
 
         /// <summary>
         /// Expressions that show as columns when the signal is selected in the events screen.

--- a/src/Seq.Api/Model/Tasks/RunningTaskEntity.cs
+++ b/src/Seq.Api/Model/Tasks/RunningTaskEntity.cs
@@ -14,18 +14,13 @@
 
 using System;
 
-namespace Seq.Api.Model.Diagnostics
+namespace Seq.Api.Model.Tasks
 {
     /// <summary>
     /// Describes a task being actively performed by the Seq server.
     /// </summary>
-    public class RunningTaskPart
+    public class RunningTaskEntity: Entity
     {
-        /// <summary>
-        /// A unique identifier for the task.
-        /// </summary>
-        public Guid Id { get; set; }
-
         /// <summary>
         /// A description of the task.
         /// </summary>
@@ -35,5 +30,10 @@ namespace Seq.Api.Model.Diagnostics
         /// When the task started.
         /// </summary>
         public DateTime StartedAtUtc { get; set; }
+
+        /// <summary>
+        /// Whether or not the task can be cancelled.
+        /// </summary>
+        public bool CanCancel { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Users/UserEntity.cs
+++ b/src/Seq.Api/Model/Users/UserEntity.cs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 using System.Collections.Generic;
+using Newtonsoft.Json;
+using Seq.Api.Model.Shared;
 using Seq.Api.Model.Signals;
 
 namespace Seq.Api.Model.Users
@@ -46,19 +48,22 @@ namespace Seq.Api.Model.Users
         /// <summary>
         /// If changing password, the new password for the user.
         /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string NewPassword { get; set; }
 
         /// <summary>
         /// A filter that is applied to searches and queries instigated by
         /// the user.
         /// </summary>
-        public SignalFilterPart ViewFilter { get; set; }
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public DescriptiveFilterPart ViewFilter { get; set; }
 
         /// <summary>
         /// If <c>true</c>, the user will be unable to log in without first
         /// changing their password. Recommended when administratively assigning
         /// a password for the user.
         /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public bool MustChangePassword { get; set; }
 
         /// <summary>
@@ -66,5 +71,21 @@ namespace Seq.Api.Model.Users
         /// the Seq UI currently only supports a single role when editing users.
         /// </summary>
         public HashSet<string> RoleIds { get; set; } = new HashSet<string>();
+
+        /// <summary>
+        /// The authentication provider associated with the user account. This will normally be
+        /// the system-configured authentication provider, but if the provider is changed, the
+        /// user may need to be unlinked from an existing provider so that login can proceed through
+        /// the new provider.
+        /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string AuthenticationProvider { get; set; }
+
+        /// <summary>
+        /// The unique identifier that links the identity provided by the authentication provider
+        /// with the Seq user.
+        /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string AuthenticationProviderUniqueIdentifier { get; set; }
     }
 }

--- a/src/Seq.Api/ResourceGroups/AlertStateResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/AlertStateResourceGroup.cs
@@ -21,7 +21,7 @@ using Seq.Api.Model.Monitoring;
 namespace Seq.Api.ResourceGroups
 {
     /// <summary>
-    /// Inspect the current states of alerts being monitored by the server..
+    /// Inspect the current states of alerts being monitored by the server.
     /// </summary>
     public class AlertStateResourceGroup : ApiResourceGroup
     {

--- a/src/Seq.Api/ResourceGroups/ApiKeysResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/ApiKeysResourceGroup.cs
@@ -17,6 +17,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Seq.Api.Model;
+using Seq.Api.Model.Diagnostics;
 using Seq.Api.Model.Inputs;
 using Seq.Api.Model.Users;
 
@@ -106,6 +107,19 @@ namespace Seq.Api.ResourceGroups
         public async Task UpdateAsync(ApiKeyEntity entity, CancellationToken cancellationToken = default)
         {
             await Client.PutAsync(entity, "Self", entity, cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Retrieve a detailed metric for the API key.
+        /// </summary>
+        /// <param name="entity">The API key to retrieve metrics for.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <param name="measurement">The measurement to get.</param>
+        /// <returns></returns>
+        public async Task<MeasurementTimeseriesPart> GetMeasurementTimeseriesAsync(ApiKeyEntity entity, string measurement, CancellationToken cancellationToken = default)
+        {
+            var parameters = new Dictionary<string, object>{ ["id"] = entity.Id, ["measurement"] = measurement };
+            return await GroupGetAsync<MeasurementTimeseriesPart>("Metric", parameters, cancellationToken);
         }
     }
 }

--- a/src/Seq.Api/ResourceGroups/AppInstancesResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/AppInstancesResourceGroup.cs
@@ -19,6 +19,7 @@ using System.Threading.Tasks;
 using Seq.Api.Model;
 using Seq.Api.Model.AppInstances;
 using Seq.Api.Model.Apps;
+using Seq.Api.Model.Diagnostics;
 
 namespace Seq.Api.ResourceGroups
 {
@@ -121,6 +122,19 @@ namespace Seq.Api.ResourceGroups
 
             var postedSettings = settingOverrides ?? new Dictionary<string, string>();
             await Client.PostAsync(entity, "Invoke", postedSettings, new Dictionary<string, object>{{"eventId", eventId}}, cancellationToken);
+        }
+        
+        /// <summary>
+        /// Retrieve a detailed metric for the app instance.
+        /// </summary>
+        /// <param name="entity">The app instance to retrieve metrics for.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <param name="measurement">The measurement to get.</param>
+        /// <returns></returns>
+        public async Task<MeasurementTimeseriesPart> GetMeasurementTimeseriesAsync(AppInstanceEntity entity, string measurement, CancellationToken cancellationToken = default)
+        {
+            var parameters = new Dictionary<string, object>{ ["id"] = entity.Id, ["measurement"] = measurement };
+            return await GroupGetAsync<MeasurementTimeseriesPart>("Metric", parameters, cancellationToken);
         }
     }
 }

--- a/src/Seq.Api/ResourceGroups/DiagnosticsResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/DiagnosticsResourceGroup.cs
@@ -12,9 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Seq.Api.Model.Diagnostics;
+using Seq.Api.Model.Inputs;
 
 namespace Seq.Api.ResourceGroups
 {
@@ -56,6 +58,18 @@ namespace Seq.Api.ResourceGroups
         public async Task<string> GetIngestionLogAsync(CancellationToken cancellationToken = default)
         {
             return await GroupGetStringAsync("IngestionLog", cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+        
+        /// <summary>
+        /// Retrieve a detailed system metric.
+        /// </summary>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <param name="measurement">The measurement to get.</param>
+        /// <returns></returns>
+        public async Task<MeasurementTimeseriesPart> GetMeasurementTimeseriesAsync(string measurement, CancellationToken cancellationToken = default)
+        {
+            var parameters = new Dictionary<string, object>{ ["measurement"] = measurement };
+            return await GroupGetAsync<MeasurementTimeseriesPart>("Metric", parameters, cancellationToken);
         }
     }
 }

--- a/src/Seq.Api/ResourceGroups/RunningTasksResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/RunningTasksResourceGroup.cs
@@ -1,0 +1,66 @@
+﻿// Copyright Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Seq.Api.Model.Monitoring;
+using Seq.Api.Model.Tasks;
+
+namespace Seq.Api.ResourceGroups
+{
+    /// <summary>
+    /// Inspect and cancel tasks running in the Seq server.
+    /// </summary>
+    public class RunningTasksResourceGroup : ApiResourceGroup
+    {
+        internal RunningTasksResourceGroup (ISeqConnection connection)
+            : base("RunningTasks", connection)
+        {
+        }
+
+        /// <summary>
+        /// Retrieve the task with the given id; throws if the entity does not exist.
+        /// </summary>
+        /// <param name="id">The id of the task.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The task.</returns>
+        public async Task<RunningTaskEntity> FindAsync(string id, CancellationToken cancellationToken = default)
+        {
+            if (id == null) throw new ArgumentNullException(nameof(id));
+            return await GroupGetAsync<RunningTaskEntity>("Item", new Dictionary<string, object> { { "id", id } }, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Retrieve all tasks running on the server.
+        /// </summary>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>A list containing all running tasks.</returns>
+        public async Task<List<RunningTaskEntity>> ListAsync(CancellationToken cancellationToken = default)
+        {
+            return await GroupListAsync<RunningTaskEntity>("Items", null, cancellationToken).ConfigureAwait(false);
+        }
+    
+        /// <summary>
+        /// Request cancellation of a running task. The task must support cancellation; see <see cref="RunningTaskEntity.CanCancel"/>.
+        /// </summary>
+        /// <param name="entity">The task to cancel.</param>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> allowing the cancellation operation itself to be canceled.</param>
+        public async Task RequestCancellationAsync(AlertStateEntity entity, CancellationToken cancellationToken = default)
+        {
+            await Client.DeleteAsync(entity, "Self", entity, cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Seq.Api/SeqConnection.cs
+++ b/src/Seq.Api/SeqConnection.cs
@@ -152,6 +152,11 @@ namespace Seq.Api
         public RolesResourceGroup Roles => new RolesResourceGroup(this);
 
         /// <summary>
+        /// Perform operations on tasks running in the Seq server.
+        /// </summary>
+        public RunningTasksResourceGroup RunningTasks => new RunningTasksResourceGroup(this);
+
+        /// <summary>
         /// Perform operations on system settings.
         /// </summary>
         public SettingsResourceGroup Settings => new SettingsResourceGroup(this);


### PR DESCRIPTION
 * `SeqApiClient` now accepts `application/vnd.datalust.seq.v8+json`, the media type indicating 2020.1 API support
 * `AppInstanceEntity.InputSignalExpression` renamed to `StreamedSignalExpression` to avoid confusion with _inputs_
 * `AppInstanceEntity.InputSettings` added, to support filtering, property tagging, etc.
 * `AppInstanceEntity.Metrics` split into `ProcessMetrics`, `InputMetrics`, `DiagnosticInputMetrics` and `OutputMetrics` (with corresponding split of `AppInstanceMetricsPart`)
 * `RunningTaskPart` moved from _Seq.Api.Model.Diagnostics_ to _RunningTasks_
 * `Entity` carries `ExtensionData` to ease backwards compatibility on the server-side
 * `ApiKeyEntity.InputFilter`, `MinimumLevel`, `UseServerTimestamps` and `AppliedProperties` moved to `ApiKeyEntity.InputSettings`
 * New `SettingName` entries for various OpenID Connect settings, `AuthenticationProvider`, `AutomaticallyProvisionAuthenticatedUsers`, and `AzureADAuthority`; some obsolete settings removed/marked
 * `SignalFilterPart` renamed to `DescriptiveFilterPart`, to clarify its use across the API and not only with signals
 * `SeqConnection.RunningTasks` added to support diagnostics and task cancellation
 * `UserEntity` now exposes `AuthenticationProvider` and `AuthenticationProviderUniqueIdentifier`
 * `ApiKeysResourceGroup`, `AppInstancesResourceGroup` and `DiagnosticsResourceGroup` now expose `GetMeasurementTimeseriesAsync()` for 24-hr metric histograms

Phew! We've been busy 😅