### PR TITLE
2020.1.0 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ If you want to *write events* to Seq, use one of the logging framework clients, 
 Install from NuGet:
 
 ```powershell
-Install-Package Seq.Api
+dotnet add package Seq.Api
 ```
 
 Create a `SeqConnection` with your server URL:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,6 @@
 version: '{build}'
 skip_tags: true
-image: Visual Studio 2017
-configuration: Release
-install:
+image: Visual Studio 2019
 build_script:
 - ps: ./Build.ps1
 test: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ artifacts:
 deploy:
 - provider: NuGet
   api_key:
-    secure: jFkBflAkupwH+6ebPfcScQzBwCJGArjzcE6716DMgVG5SSktBSXIgAtPE2URki8r
+    secure: sMicBLl7Z83H/mhX10DL7Yqwa80ZHUbb9fRHKmxd5m2MN2DWAE1kbYH/GPQPFajZ
   skip_symbols: true
   on:
     branch: /^(master|dev)$/

--- a/example/SignalCopy/Program.cs
+++ b/example/SignalCopy/Program.cs
@@ -94,7 +94,7 @@ Options:
 
                 target.Title = signal.Title;
                 target.Filters = signal.Filters;
-                target.TaggedProperties = signal.TaggedProperties;
+                target.Columns = signal.Columns;
                 target.Description = signal.Description + " (copy)";
 
                 await (target.Id != null ? dstConnection.Signals.UpdateAsync(target) : dstConnection.Signals.AddAsync(target));

--- a/seq-api.sln.DotSettings
+++ b/seq-api.sln.DotSettings
@@ -1,11 +1,16 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=AD/@EntryIndexedValue">AD</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=apikey/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Datalust/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=dstkey/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=hrefs/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Parameterize/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=permalinked/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=permalinks/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Permalinks/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Reentrant/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Serilog/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=srckey/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Unsubscriber/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Workspaces/@EntryIndexedValue">True</s:Boolean>
 </wpf:ResourceDictionary>

--- a/seq-api.sln.DotSettings
+++ b/seq-api.sln.DotSettings
@@ -2,15 +2,27 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=AD/@EntryIndexedValue">AD</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=apikey/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Datalust/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=donut/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=dstkey/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=ffee/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Gravatar/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=hrefs/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Invalidations/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Iocp/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Parameterize/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=permalinked/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=permalinks/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Permalinks/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Reentrant/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=seqbak/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Seq_0027s/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Serilog/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=srckey/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=strikethrough/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=templated/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=timeseries/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=tokenless/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Unsubscriber/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Uptime/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Workspaces/@EntryIndexedValue">True</s:Boolean>
 </wpf:ResourceDictionary>

--- a/src/Seq.Api/Client/SeqApiClient.cs
+++ b/src/Seq.Api/Client/SeqApiClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Client/SeqApiClient.cs
+++ b/src/Seq.Api/Client/SeqApiClient.cs
@@ -42,7 +42,7 @@ namespace Seq.Api.Client
         // Future versions of Seq may not completely support v1 features, however
         // providing this as an Accept header will ensure what compatibility is available
         // can be utilized.
-        const string SeqApiV7MediaType = "application/vnd.datalust.seq.v7+json";
+        const string SeqApiV8MediaType = "application/vnd.datalust.seq.v8+json";
 
         readonly CookieContainer _cookies = new CookieContainer();
         readonly JsonSerializer _serializer = JsonSerializer.Create(
@@ -89,7 +89,7 @@ namespace Seq.Api.Client
                 baseAddress += "/";
 
             HttpClient = new HttpClient(handler) { BaseAddress = new Uri(baseAddress) };
-            HttpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(SeqApiV7MediaType));
+            HttpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(SeqApiV8MediaType));
 
             if (_apiKey != null)
                 HttpClient.DefaultRequestHeaders.Add("X-Seq-ApiKey", _apiKey);

--- a/src/Seq.Api/Client/SeqApiClient.cs
+++ b/src/Seq.Api/Client/SeqApiClient.cs
@@ -35,7 +35,7 @@ namespace Seq.Api.Client
                 Converters = { new StringEnumConverter(), new LinkCollectionConverter() }
             });
 
-        public SeqApiClient(string serverUrl, string apiKey = null, bool useDefaultCredentials = true)
+        public SeqApiClient(string serverUrl, string apiKey = null, bool useDefaultCredentials = true, TimeSpan? requestTimeout = null)
         {
             ServerUrl = serverUrl ?? throw new ArgumentNullException(nameof(serverUrl));
 
@@ -53,6 +53,8 @@ namespace Seq.Api.Client
                 baseAddress += "/";
 
             HttpClient = new HttpClient(handler) { BaseAddress = new Uri(baseAddress) };
+            if (requestTimeout != null)
+                HttpClient.Timeout = requestTimeout.Value;
         }
 
         public string ServerUrl { get; }
@@ -199,7 +201,7 @@ namespace Seq.Api.Client
             if (payload != null && payload.TryGetValue("Error", out var error) && error != null)
                 throw new SeqApiException($"{(int)response.StatusCode} - {error}", response.StatusCode);
 
-            throw new SeqApiException($"The Seq request failed ({(int)response.StatusCode}).", response.StatusCode);
+            throw new SeqApiException($"The Seq request failed ({(int)response.StatusCode}/{response.StatusCode}).", response.StatusCode);
         }
 
         HttpContent MakeJsonContent(object content)

--- a/src/Seq.Api/Client/SeqApiClient.cs
+++ b/src/Seq.Api/Client/SeqApiClient.cs
@@ -14,6 +14,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using System.Net;
 using System.Net.Http;
@@ -56,7 +57,20 @@ namespace Seq.Api.Client
         /// <param name="serverUrl">The base URL of the Seq server.</param>
         /// <param name="apiKey">An API key to use when making requests to the server, if required.</param>
         /// <param name="useDefaultCredentials">Whether default credentials will be sent with HTTP requests; the default is <c>true</c>.</param>
-        public SeqApiClient(string serverUrl, string apiKey = null, bool useDefaultCredentials = true)
+        [Obsolete("Prefer `SeqApiClient(serverUrl, apiKey, handler => handler.UseDefaultCredentials = true)` instead."), EditorBrowsable(EditorBrowsableState.Never)]
+        public SeqApiClient(string serverUrl, string apiKey, bool useDefaultCredentials)
+            : this(serverUrl, apiKey, handler => handler.UseDefaultCredentials = useDefaultCredentials)
+        {
+        }
+
+        /// <summary>
+        /// Construct a <see cref="SeqApiClient"/>.
+        /// </summary>
+        /// <param name="serverUrl">The base URL of the Seq server.</param>
+        /// <param name="apiKey">An API key to use when making requests to the server, if required.</param>
+        /// <param name="configureHttpClientHandler">An optional callback to configure the <see cref="HttpClientHandler"/> used when making HTTP requests
+        /// to the Seq API.</param>
+        public SeqApiClient(string serverUrl, string apiKey = null, Action<HttpClientHandler> configureHttpClientHandler = null)
         {
             ServerUrl = serverUrl ?? throw new ArgumentNullException(nameof(serverUrl));
 
@@ -65,9 +79,10 @@ namespace Seq.Api.Client
 
             var handler = new HttpClientHandler
             {
-                CookieContainer = _cookies,
-                UseDefaultCredentials = useDefaultCredentials
+                CookieContainer = _cookies
             };
+
+            configureHttpClientHandler?.Invoke(handler);
 
             var baseAddress = serverUrl;
             if (!baseAddress.EndsWith("/"))

--- a/src/Seq.Api/Client/SeqApiClient.cs
+++ b/src/Seq.Api/Client/SeqApiClient.cs
@@ -15,7 +15,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -26,7 +25,6 @@ using Newtonsoft.Json.Converters;
 using Seq.Api.Model;
 using Seq.Api.Model.Root;
 using Seq.Api.Serialization;
-using Tavis.UriTemplates;
 using System.Threading;
 using Seq.Api.Streams;
 using System.Net.WebSockets;
@@ -58,9 +56,7 @@ namespace Seq.Api.Client
         /// <param name="serverUrl">The base URL of the Seq server.</param>
         /// <param name="apiKey">An API key to use when making requests to the server, if required.</param>
         /// <param name="useDefaultCredentials">Whether default credentials will be sent with HTTP requests; the default is <c>true</c>.</param>
-        /// <param name="requestTimeout">The time to wait before canceling long-running HTTP requests; the default (<c>null</c>) is to use the
-        /// system request timeout, normally 100 seconds. To disable timing out at the client, pass <see cref="Timeout.InfiniteTimeSpan"/>.</param>
-        public SeqApiClient(string serverUrl, string apiKey = null, bool useDefaultCredentials = true, TimeSpan? requestTimeout = null)
+        public SeqApiClient(string serverUrl, string apiKey = null, bool useDefaultCredentials = true)
         {
             ServerUrl = serverUrl ?? throw new ArgumentNullException(nameof(serverUrl));
 
@@ -82,9 +78,6 @@ namespace Seq.Api.Client
 
             if (_apiKey != null)
                 HttpClient.DefaultRequestHeaders.Add("X-Seq-ApiKey", _apiKey);
-
-            if (requestTimeout != null)
-                HttpClient.Timeout = requestTimeout.Value;
         }
 
         /// <summary>

--- a/src/Seq.Api/Client/SeqApiException.cs
+++ b/src/Seq.Api/Client/SeqApiException.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Client/SeqApiException.cs
+++ b/src/Seq.Api/Client/SeqApiException.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Net;
 
 namespace Seq.Api.Client

--- a/src/Seq.Api/Model/AppInstances/AppInstanceEntity.cs
+++ b/src/Seq.Api/Model/AppInstances/AppInstanceEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/AppInstances/AppInstanceEntity.cs
+++ b/src/Seq.Api/Model/AppInstances/AppInstanceEntity.cs
@@ -1,13 +1,37 @@
-﻿using System;
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using Seq.Api.Model.Apps;
 using Seq.Api.Model.Signals;
+using Seq.Api.ResourceGroups;
 
 namespace Seq.Api.Model.AppInstances
 {
+    /// <summary>
+    /// App instances are individual processes based on a running <see cref="AppEntity"/> that can
+    /// read from and write to the Seq event stream.
+    /// </summary>
     public class AppInstanceEntity : Entity
     {
+        /// <summary>
+        /// Construct an <see cref="AppInstanceEntity"/> with default values.
+        /// </summary>
+        /// <remarks>Instead of constructing an instance directly, consider using
+        /// <see cref="AppInstancesResourceGroup.TemplateAsync"/> to obtain a partly-initialized instance.</remarks>
         public AppInstanceEntity()
         {
             Settings = new Dictionary<string, string>();
@@ -17,8 +41,19 @@ namespace Seq.Api.Model.AppInstances
             Metrics = new AppInstanceMetricsPart();
         }
 
+        /// <summary>
+        /// The id of the <see cref="AppEntity"/> that this is an instance of.
+        /// </summary>
         public string AppId { get; set; }
+
+        /// <summary>
+        /// The user-friendly title of the app instance.
+        /// </summary>
         public string Title { get; set; }
+
+        /// <summary>
+        /// Values for the settings exposed by the app.
+        /// </summary>
         public Dictionary<string, string> Settings { get; set; }
 
         /// <summary>
@@ -32,25 +67,67 @@ namespace Seq.Api.Model.AppInstances
         /// as the target for alert notifications.
         /// </summary>
         public bool AcceptDirectInvocation { get; set; }
+
+        /// <summary>
+        /// The settings that can be overridden at invocation time (when an event is sent to
+        /// the instance).
+        /// </summary>
         public List<string> InvocationOverridableSettings { get; set; }
+
+        /// <summary>
+        /// Metadata describing the overridable settings. This field is provided by the server
+        /// and cannot be modified.
+        /// </summary>
         public List<AppSettingPart> InvocationOverridableSettingDefinitions { get; set; }
 
         /// <summary>
-        /// If <c>true</c>, events will be streamed to the app.
+        /// If <c>true</c>, events will be streamed to the app. Otherwise, events will be
+        /// sent only manually or in response to alerts being triggered.
         /// </summary>
         public bool AcceptStreamedEvents { get; set; }
+
+        /// <summary>
+        /// The signal expression describing which events will be sent to the app; if <c>null</c>,
+        /// all events will reach the app.
+        /// </summary>
         public SignalExpressionPart InputSignalExpression { get; set; }
+
+        /// <summary>
+        /// If a value is specified, events will be buffered to disk and sorted by timestamp-order
+        /// within the specified window. This is not recommended for performance reasons, and should
+        /// be avoided when possible.
+        /// </summary>
         public TimeSpan? ArrivalWindow { get; set; }
+
+        /// <summary>
+        /// The time after an event reaches the app during which no further events will be processed.
+        /// The default <see cref="TimeSpan.Zero"/> indicates no suppression time, and all events
+        /// will be processed in that case.
+        /// </summary>
         public TimeSpan SuppressionTime { get; set; }
+
+        /// <summary>
+        /// If <see cref="SuppressionTime"/> is set, the number of events that will be allowed during the
+        /// suppression window. The default is <c>1</c>, to allow only the initial event that triggered suppression.
+        /// </summary>
         public int EventsPerSuppressionWindow { get; set; }
 
+        /// <summary>
+        /// Metrics describing the state and activity of the app.
+        /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public AppInstanceMetricsPart Metrics { get; set; }
 
+        /// <summary>
+        /// Obsolete.
+        /// </summary>
         [Obsolete("Use !AcceptStreamedEvents instead. This field will be removed in Seq 6.0.")]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public bool? IsManualInputOnly { get; set; }
 
+        /// <summary>
+        /// Obsolete.
+        /// </summary>
         [Obsolete("Use !AcceptDirectInvocation instead. This field will be removed in Seq 6.0.")]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public bool? DisallowManualInput { get; set; }

--- a/src/Seq.Api/Model/AppInstances/AppInstanceEntity.cs
+++ b/src/Seq.Api/Model/AppInstances/AppInstanceEntity.cs
@@ -16,6 +16,7 @@ using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using Seq.Api.Model.Apps;
+using Seq.Api.Model.Inputs;
 using Seq.Api.Model.Signals;
 using Seq.Api.ResourceGroups;
 
@@ -38,7 +39,11 @@ namespace Seq.Api.Model.AppInstances
             InvocationOverridableSettings = new List<string>();
             InvocationOverridableSettingDefinitions = new List<AppSettingPart>();
             EventsPerSuppressionWindow = 1;
-            Metrics = new AppInstanceMetricsPart();
+            ProcessMetrics = new AppInstanceProcessMetricsPart();
+            InputSettings = new InputSettingsPart();
+            InputMetrics = new InputMetricsPart();
+            DiagnosticInputMetrics = new InputMetricsPart();
+            OutputMetrics = new AppInstanceOutputMetricsPart();
         }
 
         /// <summary>
@@ -90,7 +95,7 @@ namespace Seq.Api.Model.AppInstances
         /// The signal expression describing which events will be sent to the app; if <c>null</c>,
         /// all events will reach the app.
         /// </summary>
-        public SignalExpressionPart InputSignalExpression { get; set; }
+        public SignalExpressionPart StreamedSignalExpression { get; set; }
 
         /// <summary>
         /// If a value is specified, events will be buffered to disk and sorted by timestamp-order
@@ -113,22 +118,46 @@ namespace Seq.Api.Model.AppInstances
         public int EventsPerSuppressionWindow { get; set; }
 
         /// <summary>
-        /// Metrics describing the state and activity of the app.
+        /// Settings that control how events are ingested through the app.
         /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public AppInstanceMetricsPart Metrics { get; set; }
+        public InputSettingsPart InputSettings { get; set; }
 
+        /// <summary>
+        /// Metrics describing the state and activity of the app process.
+        /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public AppInstanceProcessMetricsPart ProcessMetrics { get; set; }
+        
+        /// <summary>
+        /// Information about ingestion activity through this app.
+        /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public InputMetricsPart InputMetrics { get; set; }
+
+        /// <summary>
+        /// Information about the app's diagnostic input.
+        /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public InputMetricsPart DiagnosticInputMetrics { get; set; }
+
+        /// <summary>
+        /// Information about events output through the app.
+        /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public AppInstanceOutputMetricsPart OutputMetrics { get; set; }
+        
         /// <summary>
         /// Obsolete.
         /// </summary>
-        [Obsolete("Use !AcceptStreamedEvents instead. This field will be removed in Seq 6.0.")]
+        [Obsolete("Use !AcceptStreamedEvents instead.")]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public bool? IsManualInputOnly { get; set; }
 
         /// <summary>
         /// Obsolete.
         /// </summary>
-        [Obsolete("Use !AcceptDirectInvocation instead. This field will be removed in Seq 6.0.")]
+        [Obsolete("Use !AcceptDirectInvocation instead.")]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public bool? DisallowManualInput { get; set; }
     }

--- a/src/Seq.Api/Model/AppInstances/AppInstanceMetricsPart.cs
+++ b/src/Seq.Api/Model/AppInstances/AppInstanceMetricsPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/AppInstances/AppInstanceMetricsPart.cs
+++ b/src/Seq.Api/Model/AppInstances/AppInstanceMetricsPart.cs
@@ -1,10 +1,43 @@
-﻿namespace Seq.Api.Model.AppInstances
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Seq.Api.Model.AppInstances
 {
+    /// <summary>
+    /// Metrics describing an <see cref="AppInstanceEntity"/>.
+    /// </summary>
     public class AppInstanceMetricsPart
     {
+        /// <summary>
+        /// The number of events that reached the app in the past minute.
+        /// </summary>
         public int ReceivedEventsPerMinute { get; set; }
+
+        /// <summary>
+        /// The number of diagnostic events raised by the app in the past minute.
+        /// </summary>
+        /// <remarks>This does not include the events received by an input app.</remarks>
         public int EmittedEventsPerMinute { get; set; }
+
+        /// <summary>
+        /// The size, in bytes, of the app process working set.
+        /// </summary>
         public long ProcessWorkingSetBytes { get; set; }
+
+        /// <summary>
+        /// If the app process is running, <c>true</c>; otherwise, <c>false</c>.
+        /// </summary>
         public bool IsRunning { get; set; }
     }
 }

--- a/src/Seq.Api/Model/AppInstances/AppInstanceOutputMetricsPart.cs
+++ b/src/Seq.Api/Model/AppInstances/AppInstanceOutputMetricsPart.cs
@@ -1,0 +1,15 @@
+namespace Seq.Api.Model.AppInstances
+{
+    /// <summary>
+    /// Describes the events reaching being output from Seq through the app.
+    /// </summary>
+    public class AppInstanceOutputMetricsPart
+    {
+        /// <summary>
+        /// The number of events per minute sent from Seq to the app. Includes streamed events (if enabled),
+        /// manual invocations, and alert notifications. There may be some delay between dispatching an event, and
+        /// it being processed by the app.
+        /// </summary>
+        public int DispatchedEventsPerMinute { get; set; }
+    }
+}

--- a/src/Seq.Api/Model/AppInstances/AppInstanceProcessMetricsPart.cs
+++ b/src/Seq.Api/Model/AppInstances/AppInstanceProcessMetricsPart.cs
@@ -15,25 +15,14 @@
 namespace Seq.Api.Model.AppInstances
 {
     /// <summary>
-    /// Metrics describing an <see cref="AppInstanceEntity"/>.
+    /// Metrics describing the running server-side process for an <see cref="AppInstanceEntity"/>.
     /// </summary>
-    public class AppInstanceMetricsPart
+    public class AppInstanceProcessMetricsPart
     {
-        /// <summary>
-        /// The number of events that reached the app in the past minute.
-        /// </summary>
-        public int ReceivedEventsPerMinute { get; set; }
-
-        /// <summary>
-        /// The number of diagnostic events raised by the app in the past minute.
-        /// </summary>
-        /// <remarks>This does not include the events received by an input app.</remarks>
-        public int EmittedEventsPerMinute { get; set; }
-
         /// <summary>
         /// The size, in bytes, of the app process working set.
         /// </summary>
-        public long ProcessWorkingSetBytes { get; set; }
+        public long WorkingSetBytes { get; set; }
 
         /// <summary>
         /// If the app process is running, <c>true</c>; otherwise, <c>false</c>.

--- a/src/Seq.Api/Model/Apps/AppEntity.cs
+++ b/src/Seq.Api/Model/Apps/AppEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Apps/AppEntity.cs
+++ b/src/Seq.Api/Model/Apps/AppEntity.cs
@@ -1,25 +1,62 @@
-﻿using System;
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 using System.Collections.Generic;
-using Newtonsoft.Json;
+using Seq.Api.ResourceGroups;
 
 namespace Seq.Api.Model.Apps
 {
+    /// <summary>
+    /// Seq apps are executable plug-ins that read from and write to the Seq event stream.
+    /// </summary>
     public class AppEntity : Entity
     {
+        /// <summary>
+        /// Construct an <see cref="AppEntity"/> with default values.
+        /// </summary>
+        /// <remarks>Instead of constructing an instance directly, consider using
+        /// <see cref="AppsResourceGroup.TemplateAsync"/> to obtain a partly-initialized instance.</remarks>
         public AppEntity()
         {
             Name = "New App";
             AvailableSettings = new List<AppSettingPart>();
         }
 
+        /// <summary>
+        /// The friendly name of the app.
+        /// </summary>
         public string Name { get; set; }
 
+        /// <summary>
+        /// A long-form description of the app.
+        /// </summary>
         public string Description { get; set; }
 
+        /// <summary>
+        /// Metadata describing the settings exposed by instances of the app.
+        /// </summary>
         public List<AppSettingPart> AvailableSettings { get; set; }
 
+        /// <summary>
+        /// Whether instances of the app can safely process their own diagnostic events. The
+        /// default is <c>false</c>. This option should not normally be set.
+        /// </summary>
         public bool AllowReprocessing { get; set; }
 
+        /// <summary>
+        /// Metadata describing the NuGet package containing the executable app components.
+        /// </summary>
         public AppPackagePart Package { get; set; }
 
         /// <summary>

--- a/src/Seq.Api/Model/Apps/AppPackagePart.cs
+++ b/src/Seq.Api/Model/Apps/AppPackagePart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Apps/AppPackagePart.cs
+++ b/src/Seq.Api/Model/Apps/AppPackagePart.cs
@@ -1,13 +1,59 @@
-﻿namespace Seq.Api.Model.Apps
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Seq.Api.Model.Feeds;
+
+namespace Seq.Api.Model.Apps
 {
+    /// <summary>
+    /// Describes a NuGet package containing executable app components.
+    /// </summary>
     public class AppPackagePart
     {
+        /// <summary>
+        /// The id of the <see cref="NuGetFeedEntity"/> from which the package was installed.
+        /// </summary>
         public string NuGetFeedId { get; set; }
+
+        /// <summary>
+        /// The package id, for example <c>Seq.Input.HealthCheck</c>.
+        /// </summary>
         public string PackageId { get; set; }
+
+        /// <summary>
+        /// The version of the package.
+        /// </summary>
         public string Version { get; set; }
+
+        /// <summary>
+        /// Package authorship information.
+        /// </summary>
         public string Authors { get; set; }
+
+        /// <summary>
+        /// URL of an icon for the app package.
+        /// </summary>
         public string IconUrl { get; set; }
+
+        /// <summary>
+        /// URL of the package license.
+        /// </summary>
         public string LicenseUrl { get; set; }
+
+        /// <summary>
+        /// Whether an update is known to be available for the app.
+        /// </summary>
         public bool UpdateAvailable { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Apps/AppSettingPart.cs
+++ b/src/Seq.Api/Model/Apps/AppSettingPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Apps/AppSettingPart.cs
+++ b/src/Seq.Api/Model/Apps/AppSettingPart.cs
@@ -1,11 +1,50 @@
-﻿namespace Seq.Api.Model.Apps
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Seq.Api.Model.Apps
 {
+    /// <summary>
+    /// Describes a setting exposed by instances of an <see cref="AppEntity"/>.
+    /// </summary>
     public class AppSettingPart
     {
+        /// <summary>
+        /// The unique name identifying the setting.
+        /// </summary>
         public string Name { get; set; }
+
+        /// <summary>
+        /// A friendly, descriptive name of the setting.
+        /// </summary>
         public string DisplayName { get; set; }
+
+        /// <summary>
+        /// Whether the setting is required in order for the app to function.
+        /// </summary>
         public bool IsOptional { get; set; }
+
+        /// <summary>
+        /// Long-form description of the setting.
+        /// </summary>
         public string HelpText { get; set; }
+
+        /// <summary>
+        /// The type of value accepted for the setting; valid values are <c>Text</c>,
+        /// <c>LongText</c>, <c>Checkbox</c>, <c>Integer</c>, <c>Decimal</c>, and <c>Password</c>.
+        /// </summary>
+        /// <remarks>An enum was historically not used here in order to improve
+        /// forwards/backwards compatibility.</remarks>
         public string Type { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Backups/BackupEntity.cs
+++ b/src/Seq.Api/Model/Backups/BackupEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Backups/BackupEntity.cs
+++ b/src/Seq.Api/Model/Backups/BackupEntity.cs
@@ -1,9 +1,40 @@
-﻿namespace Seq.Api.Model.Backups
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Seq.Api.Model.Backups
 {
+    /// <summary>
+    /// Seq backups include metadata like users, signals, API keys and other configuration, but do not include
+    /// the event stream. Backups are fully encrypted with AES-256 and cannot be restored without the master key
+    /// from the originating Seq instance.
+    /// </summary>
     public class BackupEntity : Entity
     {
+        /// <summary>
+        /// The time at which the backup was created (ISO-8601-encoded date/time).
+        /// </summary>
         public string CreatedAt { get; set; }
+
+        /// <summary>
+        /// The filename (without path information) of the backup, within the server's
+        /// configured backup location.
+        /// </summary>
         public string Filename { get; set; }
+
+        /// <summary>
+        /// The size, in bytes, of the backup file.
+        /// </summary>
         public long FileSizeBytes { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Data/QueryExecutionStatisticsPart.cs
+++ b/src/Seq.Api/Model/Data/QueryExecutionStatisticsPart.cs
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 Datalust and contributors. 
+// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,12 +23,12 @@ namespace Seq.Api.Model.Data
         /// The number of events inspected in the course of computing the query result. This will
         /// not include events that could be skipped based on index information or text pre-filtering.
         /// </summary>
-        public long ScannedEventCount { get; set; }
+        public ulong ScannedEventCount { get; set; }
 
         /// <summary>
         /// The number of events that contributed to the query result.
         /// </summary>
-        public long MatchingEventCount { get; set; }
+        public ulong MatchingEventCount { get; set; }
 
         /// <summary>
         /// Whether the query needed to search disk-backed storage.

--- a/src/Seq.Api/Model/Data/QueryExecutionStatisticsPart.cs
+++ b/src/Seq.Api/Model/Data/QueryExecutionStatisticsPart.cs
@@ -1,10 +1,43 @@
+// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace Seq.Api.Model.Data
 {
+    /// <summary>
+    /// Information describing the execution of a SQL-style query.
+    /// </summary>
     public class QueryExecutionStatisticsPart
     {
+        /// <summary>
+        /// The number of events inspected in the course of computing the query result. This will
+        /// not include events that could be skipped based on index information or text pre-filtering.
+        /// </summary>
         public long ScannedEventCount { get; set; }
+
+        /// <summary>
+        /// The number of events that contributed to the query result.
+        /// </summary>
         public long MatchingEventCount { get; set; }
+
+        /// <summary>
+        /// Whether the query needed to search disk-backed storage.
+        /// </summary>
         public bool UncachedSegmentsScanned { get; set; }
+
+        /// <summary>
+        /// The server-side elapsed time taken to compute the query result.
+        /// </summary>
         public double ElapsedMilliseconds { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Data/QueryResultPart.cs
+++ b/src/Seq.Api/Model/Data/QueryResultPart.cs
@@ -1,31 +1,77 @@
+// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 using Newtonsoft.Json;
 
 namespace Seq.Api.Model.Data
 {
+    /// <summary>
+    /// The result of executing a SQL-style query. Results are hierarchical, rather
+    /// than tabular, to reduce the amount of data transfer required to send events to
+    /// the client.
+    /// </summary>
+    /// <remarks>
+    /// Only one of <see cref="Rows"/>, <see cref="Slices"/>, or <see cref="Series"/>
+    /// will be present for a given result set.
+    /// Generally, the CSV-based query endpoints are more convenient to use for
+    /// simple ETL tasks.</remarks>
     public class QueryResultPart
     {
+        /// <summary>
+        /// The columns within the result set (at various levels of the hierarchy).
+        /// </summary>
         public string[] Columns { get; set; }
 
+        /// <summary>
+        /// Result rows.
+        /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public object[][] Rows { get; set; }
-        // or
+
+        /// <summary>
+        /// Result time slices.
+        /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public TimeSlicePart[] Slices { get; set; }
-        // or
+
+        /// <summary>
+        /// Result timeseries.
+        /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public TimeseriesPart[] Series { get; set; }
 
-        // On error only:
-
+        /// <summary>
+        /// On error only, a description of the error.
+        /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string Error { get; set; }
 
+        /// <summary>
+        /// Reasons for the <see cref="Error"/>.
+        /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string[] Reasons { get; set; }
 
+        /// <summary>
+        /// A corrected version of the query, if one could be suggested.
+        /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string Suggestion { get; set; }
 
+        /// <summary>
+        /// Execution statistics.
+        /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public QueryExecutionStatisticsPart Statistics { get; set; }
     }

--- a/src/Seq.Api/Model/Data/QueryResultPart.cs
+++ b/src/Seq.Api/Model/Data/QueryResultPart.cs
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 Datalust and contributors. 
+// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Data/TimeSlicePart.cs
+++ b/src/Seq.Api/Model/Data/TimeSlicePart.cs
@@ -1,8 +1,33 @@
+// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace Seq.Api.Model.Data
 {
+    /// <summary>
+    /// Results of a query for a given time slice.
+    /// </summary>
     public class TimeSlicePart
     {
+        /// <summary>
+        /// The beginning of the interval contributing to the results,
+        /// encoded as an ISO-8601 date/time string.
+        /// </summary>
         public string Time { get; set; }
+
+        /// <summary>
+        /// Result rows within the interval.
+        /// </summary>
         public object[][] Rows { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Data/TimeSlicePart.cs
+++ b/src/Seq.Api/Model/Data/TimeSlicePart.cs
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 Datalust and contributors. 
+// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Data/TimeseriesPart.cs
+++ b/src/Seq.Api/Model/Data/TimeseriesPart.cs
@@ -1,8 +1,32 @@
+// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 namespace Seq.Api.Model.Data
 {
+    /// <summary>
+    /// A series of results.
+    /// </summary>
     public class TimeseriesPart
     {
+        /// <summary>
+        /// The key (e.g. grouping columns) that identify the timeseries.
+        /// </summary>
         public object[] Key { get; set; }
+
+        /// <summary>
+        /// The timestamped slices in the series.
+        /// </summary>
         public TimeSlicePart[] Slices { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Data/TimeseriesPart.cs
+++ b/src/Seq.Api/Model/Data/TimeseriesPart.cs
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 Datalust and contributors. 
+// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Diagnostics/MeasurementTimeseriesPart.cs
+++ b/src/Seq.Api/Model/Diagnostics/MeasurementTimeseriesPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © Datalust and contributors. 
+// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,29 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace Seq.Api.Model.Inputs
+using System;
+
+namespace Seq.Api.Model.Diagnostics
 {
     /// <summary>
-    /// Information about ingestion activity using an API key.
+    /// A histogram presenting a measurement taken at equal intervals.
     /// </summary>
-    public class ApiKeyMetricsPart
+    public class MeasurementTimeseriesPart
     {
         /// <summary>
-        /// The number of events that arrived at the server tagged with this
-        /// key in the past minute.
+        /// The point in time from which measurement begins.
         /// </summary>
-        public int ArrivalsPerMinute { get; set; }
-
-        /// <summary>
-        /// The number of events that ingested by the server tagged with this
-        /// key in the past minute.
-        /// </summary>
-        public int InfluxPerMinute { get; set; }
+        public DateTime MeasuredFrom { get; set; }
         
         /// <summary>
-        /// The raw JSON bytes (approximate) tagged with this API key that were ingested
-        /// by the server in the past minute.
+        /// The interval at which the measurement is taken.
         /// </summary>
-        public long IngestedBytesPerMinute { get; set; }
+        public ulong MeasurementIntervalMilliseconds { get; set; }
+        
+        /// <summary>
+        /// The measurements at each interval, beginning with <see cref="MeasuredFrom"/>.
+        /// </summary>
+        public long[] Measurements { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Diagnostics/RunningTaskPart.cs
+++ b/src/Seq.Api/Model/Diagnostics/RunningTaskPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Diagnostics/RunningTaskPart.cs
+++ b/src/Seq.Api/Model/Diagnostics/RunningTaskPart.cs
@@ -1,11 +1,39 @@
-﻿using System;
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 
 namespace Seq.Api.Model.Diagnostics
 {
+    /// <summary>
+    /// Describes a task being actively performed by the Seq server.
+    /// </summary>
     public class RunningTaskPart
     {
+        /// <summary>
+        /// A unique identifier for the task.
+        /// </summary>
         public Guid Id { get; set; }
+
+        /// <summary>
+        /// A description of the task.
+        /// </summary>
         public string Description { get; set; }
+
+        /// <summary>
+        /// When the task started.
+        /// </summary>
         public DateTime StartedAtUtc { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Diagnostics/ServerMetricsEntity.cs
+++ b/src/Seq.Api/Model/Diagnostics/ServerMetricsEntity.cs
@@ -27,7 +27,6 @@ namespace Seq.Api.Model.Diagnostics
         /// </summary>
         public ServerMetricsEntity()
         {
-            RunningTasks = new List<RunningTaskPart>();
         }
 
         /// <summary>
@@ -41,16 +40,6 @@ namespace Seq.Api.Model.Diagnostics
         public int EventStoreEventsCached { get; set; }
 
         /// <summary>
-        /// The oldest on-disk extent currently stored.
-        /// </summary>
-        public DateTime? EventStoreFirstExtentRangeStartUtc { get; set; }
-
-        /// <summary>
-        /// The most recent on-disk extent currently stored.
-        /// </summary>
-        public DateTime? EventStoreLastExtentRangeEndUtc { get; set; }
-
-        /// <summary>
         /// Bytes of free space remaining on the disk used for event storage.
         /// </summary>
         public long EventStoreDiskRemainingBytes { get; set; }
@@ -58,27 +47,27 @@ namespace Seq.Api.Model.Diagnostics
         /// <summary>
         /// The number of events that arrived at the ingestion endpoint in the past minute.
         /// </summary>
-        public int EndpointArrivalsPerMinute { get; set; }
+        public int InputArrivedEventsPerMinute { get; set; }
 
         /// <summary>
         /// The number of events ingested in the past minute.
         /// </summary>
-        public int EndpointInfluxPerMinute { get; set; }
+        public int InputIngestedEventsPerMinute { get; set; }
 
         /// <summary>
         /// The number of bytes of raw JSON event data ingested in the past minute (approximate).
         /// </summary>
-        public long EndpointIngestedBytesPerMinute { get; set; }
+        public long InputIngestedBytesPerMinute { get; set; }
 
         /// <summary>
         /// The number of invalid event payloads seen in the past minute.
         /// </summary>
-        public int EndpointInvalidPayloadsPerMinute { get; set; }
+        public int InvalidPayloadsPerMinute { get; set; }
 
         /// <summary>
         /// The number of unauthorized event payloads seen in the past minute.
         /// </summary>
-        public int EndpointUnauthorizedPayloadsPerMinute { get; set; }
+        public int HttpUnauthorizedPayloadsPerMinute { get; set; }
 
         /// <summary>
         /// The length of time for which the Seq server process has been running.
@@ -96,24 +85,9 @@ namespace Seq.Api.Model.Diagnostics
         public int ProcessThreads { get; set; }
 
         /// <summary>
-        /// The number of thread pool user threads available.
-        /// </summary>
-        public int ProcessThreadPoolUserThreadsAvailable { get; set; }
-
-        /// <summary>
-        /// The number of async I/O thread pool threads available.
-        /// </summary>
-        public int ProcessThreadPoolIocpThreadsAvailable { get; set; }
-
-        /// <summary>
         /// The proportion of system physical memory that is currently allocated.
         /// </summary>
         public double SystemMemoryUtilization { get; set; }
-
-        /// <summary>
-        /// Tasks running in the Seq server.
-        /// </summary>
-        public List<RunningTaskPart> RunningTasks { get; set; }
 
         /// <summary>
         /// The number of SQL-style queries executed in the past minute.
@@ -129,10 +103,5 @@ namespace Seq.Api.Model.Diagnostics
         /// The number of cached SQL query time slices invalidated in the past minute.
         /// </summary>
         public int QueryCacheInvalidationsPerMinute { get; set; }
-
-        /// <summary>
-        /// The number of active sessions reading from or writing to Seq's internal metadata store.
-        /// </summary>
-        public int DocumentStoreActiveSessions { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Diagnostics/ServerMetricsEntity.cs
+++ b/src/Seq.Api/Model/Diagnostics/ServerMetricsEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Diagnostics/ServerMetricsEntity.cs
+++ b/src/Seq.Api/Model/Diagnostics/ServerMetricsEntity.cs
@@ -1,41 +1,138 @@
-﻿using System;
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
 
 namespace Seq.Api.Model.Diagnostics
 {
+    /// <summary>
+    /// Metrics describing the state and performance of the Seq server.
+    /// </summary>
     public class ServerMetricsEntity : Entity
     {
+        /// <summary>
+        /// Construct a <see cref="ServerMetricsEntity"/>.
+        /// </summary>
         public ServerMetricsEntity()
         {
             RunningTasks = new List<RunningTaskPart>();
         }
 
+        /// <summary>
+        /// The number of days of events able to fit in the memory cache.
+        /// </summary>
         public double EventStoreDaysCached { get; set; }
+
+        /// <summary>
+        /// The number of events able to fit in the memory cache.
+        /// </summary>
         public int EventStoreEventsCached { get; set; }
+
+        /// <summary>
+        /// The oldest on-disk extent currently stored.
+        /// </summary>
         public DateTime? EventStoreFirstExtentRangeStartUtc { get; set; }
+
+        /// <summary>
+        /// The most recent on-disk extent currently stored.
+        /// </summary>
         public DateTime? EventStoreLastExtentRangeEndUtc { get; set; }
+
+        /// <summary>
+        /// Bytes of free space remaining on the disk used for event storage.
+        /// </summary>
         public long EventStoreDiskRemainingBytes { get; set; }
 
+        /// <summary>
+        /// The number of events that arrived at the ingestion endpoint in the past minute.
+        /// </summary>
         public int EndpointArrivalsPerMinute { get; set; }
+
+        /// <summary>
+        /// The number of events ingested in the past minute.
+        /// </summary>
         public int EndpointInfluxPerMinute { get; set; }
+
+        /// <summary>
+        /// The number of bytes of raw JSON event data ingested in the past minute (approximate).
+        /// </summary>
         public long EndpointIngestedBytesPerMinute { get; set; }
+
+        /// <summary>
+        /// The number of invalid event payloads seen in the past minute.
+        /// </summary>
         public int EndpointInvalidPayloadsPerMinute { get; set; }
+
+        /// <summary>
+        /// The number of unauthorized event payloads seen in the past minute.
+        /// </summary>
         public int EndpointUnauthorizedPayloadsPerMinute { get; set; }
 
+        /// <summary>
+        /// The length of time for which the Seq server process has been running.
+        /// </summary>
         public TimeSpan ProcessUptime { get; set; }
+
+        /// <summary>
+        /// The number of bytes working set held by the Seq server process.
+        /// </summary>
         public long ProcessWorkingSetBytes { get; set; }
+
+        /// <summary>
+        /// The number of threads running in the Seq server process.
+        /// </summary>
         public int ProcessThreads { get; set; }
+
+        /// <summary>
+        /// The number of thread pool user threads available.
+        /// </summary>
         public int ProcessThreadPoolUserThreadsAvailable { get; set; }
+
+        /// <summary>
+        /// The number of async I/O thread pool threads available.
+        /// </summary>
         public int ProcessThreadPoolIocpThreadsAvailable { get; set; }
 
+        /// <summary>
+        /// The proportion of system physical memory that is currently allocated.
+        /// </summary>
         public double SystemMemoryUtilization { get; set; }
 
+        /// <summary>
+        /// Tasks running in the Seq server.
+        /// </summary>
         public List<RunningTaskPart> RunningTasks { get; set; }
 
+        /// <summary>
+        /// The number of SQL-style queries executed in the past minute.
+        /// </summary>
         public int QueriesPerMinute { get; set; }
+
+        /// <summary>
+        /// The number of time slices from SQL-style queries that could be read from cache in the past minute.
+        /// </summary>
         public int QueryCacheTimeSliceHitsPerMinute { get; set; }
+
+        /// <summary>
+        /// The number of cached SQL query time slices invalidated in the past minute.
+        /// </summary>
         public int QueryCacheInvalidationsPerMinute { get; set; }
 
+        /// <summary>
+        /// The number of active sessions reading from or writing to Seq's internal metadata store.
+        /// </summary>
         public int DocumentStoreActiveSessions { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Diagnostics/ServerStatusPart.cs
+++ b/src/Seq.Api/Model/Diagnostics/ServerStatusPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Diagnostics/ServerStatusPart.cs
+++ b/src/Seq.Api/Model/Diagnostics/ServerStatusPart.cs
@@ -1,7 +1,27 @@
-﻿namespace Seq.Api.Model.Diagnostics
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Seq.Api.Model.Diagnostics
 {
+    /// <summary>
+    /// Describes the status of the Seq server.
+    /// </summary>
     public class ServerStatusPart
     {
+        /// <summary>
+        /// Individual status messages.
+        /// </summary>
         public StatusMessagePart[] StatusMessages { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Diagnostics/StatusMessagePart.cs
+++ b/src/Seq.Api/Model/Diagnostics/StatusMessagePart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Diagnostics/StatusMessagePart.cs
+++ b/src/Seq.Api/Model/Diagnostics/StatusMessagePart.cs
@@ -1,8 +1,32 @@
-﻿namespace Seq.Api.Model.Diagnostics
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Seq.Api.Model.Diagnostics
 {
+    /// <summary>
+    /// A status message relating to the Seq server.
+    /// </summary>
     public class StatusMessagePart
     {
+        /// <summary>
+        /// A descriptive level (<c>Information</c>, <c>Warning</c>, or <c>Error</c>).
+        /// </summary>
         public string Level { get; set; }
+
+        /// <summary>
+        /// The message text.
+        /// </summary>
         public string Message { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Entity.cs
+++ b/src/Seq.Api/Model/Entity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Entity.cs
+++ b/src/Seq.Api/Model/Entity.cs
@@ -12,6 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
 namespace Seq.Api.Model
 {
     /// <summary>
@@ -41,5 +46,12 @@ namespace Seq.Api.Model
         /// was instantiated locally and not received from the API.
         /// </summary>
         public LinkCollection Links { get; set; }
+
+        /// <summary>
+        /// Facilitates backwards compatibility in the Seq server. Should not be used by consumers/clients.
+        /// </summary>
+        [JsonExtensionData, JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [Obsolete("Facilitates backwards compatibility in the Seq server. Should not be used by consumers/clients.")]
+        public Dictionary<string, JToken> ExtensionData { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Entity.cs
+++ b/src/Seq.Api/Model/Entity.cs
@@ -1,14 +1,42 @@
-﻿namespace Seq.Api.Model
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Seq.Api.Model
 {
+    /// <summary>
+    /// A uniquely-identifiable resource available from the Seq HTTP API.
+    /// </summary>
     public abstract class Entity : ILinked
     {
+        /// <summary>
+        /// Construct an <see cref="Entity"/>.
+        /// </summary>
         protected Entity()
         {
             Links = new LinkCollection();
         }
 
+        /// <summary>
+        /// The entity's unique identifier. This will be <c>null</c> if a newly-instantiated <see cref="Entity"/>
+        /// has not yet been sent to the server.
+        /// </summary>
         public string Id { get; set; }
 
+        /// <summary>
+        /// A collection of outbound links from the entity. This will be empty if the entity
+        /// was instantiated locally and not received from the API.
+        /// </summary>
         public LinkCollection Links { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Entity.cs
+++ b/src/Seq.Api/Model/Entity.cs
@@ -17,6 +17,9 @@ namespace Seq.Api.Model
     /// <summary>
     /// A uniquely-identifiable resource available from the Seq HTTP API.
     /// </summary>
+    /// <remarks>Entities are the persistent top-level resources that have a stable
+    /// URI. The API client uses the contrasting suffix <c>*Part</c> to designate
+    /// resources that are transient or not directly addressable.</remarks>
     public abstract class Entity : ILinked
     {
         /// <summary>

--- a/src/Seq.Api/Model/Events/DeleteResultPart.cs
+++ b/src/Seq.Api/Model/Events/DeleteResultPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Events/DeleteResultPart.cs
+++ b/src/Seq.Api/Model/Events/DeleteResultPart.cs
@@ -1,5 +1,22 @@
-﻿namespace Seq.Api.Model.Events
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Seq.Api.Model.Events
 {
+    /// <summary>
+    /// The (empty) result of executing a deletion request.
+    /// </summary>
     public class DeleteResultPart
     {
     }

--- a/src/Seq.Api/Model/Events/EventEntity.cs
+++ b/src/Seq.Api/Model/Events/EventEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Events/EventEntity.cs
+++ b/src/Seq.Api/Model/Events/EventEntity.cs
@@ -1,21 +1,62 @@
-﻿using System.Collections.Generic;
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Seq.Api.Model.Events
 {
+    /// <summary>
+    /// An event.
+    /// </summary>
     public class EventEntity : Entity
     {
+        /// <summary>
+        /// The ISO-8601 timestamp at which the event occurred.
+        /// </summary>
         public string Timestamp { get; set; }
+
+        /// <summary>
+        /// Properties associated with the event.
+        /// </summary>
         public List<EventPropertyPart> Properties { get; set; }
+
+        /// <summary>
+        /// Pre-parsed tokens showing how the event's message is constructed from its properties.
+        /// </summary>
         public List<MessageTemplateTokenPart> MessageTemplateTokens { get; set; }
+
+        /// <summary>
+        /// A string describing the event's type, in dollar-prefixed hexadecimal; e.g. <c>$c0ffee00</c>.
+        /// </summary>
         public string EventType { get; set; }
 
+        /// <summary>
+        /// A level associated with an event; <c>null</c> may indicate that the event is informational.
+        /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string Level { get; set; }
 
+        /// <summary>
+        /// An exception, stack trace/backtrace associated with the event.
+        /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string Exception { get; set; }
 
+        /// <summary>
+        /// If requested, a pre-rendered version of the templated event message.
+        /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string RenderedMessage { get; set; }
     }

--- a/src/Seq.Api/Model/Events/EventInputResultPart.cs
+++ b/src/Seq.Api/Model/Events/EventInputResultPart.cs
@@ -1,9 +1,30 @@
-﻿using Seq.Api.Model.LogEvents;
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Seq.Api.Model.LogEvents;
 
 namespace Seq.Api.Model.Events
 {
+    /// <summary>
+    /// The information returned from ingesting a batch of events.
+    /// </summary>
     public class EventInputResultPart
     {
+        /// <summary>
+        /// The minimum level at which events will be accepted by the
+        /// server.
+        /// </summary>
         public LogEventLevel? MinimumLevelAccepted { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Events/EventInputResultPart.cs
+++ b/src/Seq.Api/Model/Events/EventInputResultPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Events/EventPropertyPart.cs
+++ b/src/Seq.Api/Model/Events/EventPropertyPart.cs
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 Datalust and contributors. 
+// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Events/EventPropertyPart.cs
+++ b/src/Seq.Api/Model/Events/EventPropertyPart.cs
@@ -1,17 +1,46 @@
+// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 using System;
 
 namespace Seq.Api.Model.Events
 {
+    /// <summary>
+    /// A name/value property associated with an event.
+    /// </summary>
+    //  Note, this duplicates InputAppliedPropertyPart.
     public class EventPropertyPart
     {
+        /// <summary>
+        /// Construct an <see cref="EventPropertyPart"/>.
+        /// </summary>
+        /// <param name="name">The property name (required).</param>
+        /// <param name="value">The property value, or <c>null</c>.</param>
         public EventPropertyPart(string name, object value)
         {
-            if (name == null) throw new ArgumentNullException(nameof(name));
-            Name = name;
+            Name = name ?? throw new ArgumentNullException(nameof(name));
             Value = value;
         }
 
-        public string Name { get; private set; }
-        public object Value { get; private set; }
+        /// <summary>
+        /// The property name (required).
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// The property value, or <c>null</c>.
+        /// </summary>
+        public object Value { get; }
     }
 }

--- a/src/Seq.Api/Model/Events/MessageTemplateTokenPart.cs
+++ b/src/Seq.Api/Model/Events/MessageTemplateTokenPart.cs
@@ -1,18 +1,47 @@
+// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 using Newtonsoft.Json;
 
 namespace Seq.Api.Model.Events
 {
+    /// <summary>
+    /// A token parsed from a <a href="https://messagetemplates.org">message template</a>.
+    /// </summary>
     public class MessageTemplateTokenPart
     {
+        /// <summary>
+        /// Plain text, if the token is a text token.
+        /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string Text { get; set; }
-        // or
+
+        /// <summary>
+        /// The name of the property to be rendered in place of the token, if a property token.
+        /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string PropertyName { get; set; }
 
+        /// <summary>
+        /// The raw source text from the message template (provided for both text and property tokens).
+        /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string RawText { get; set; }
 
+        /// <summary>
+        /// A pre-formatted value, if the token carries language-specific formatting directives.
+        /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string FormattedValue { get; set; }
     }

--- a/src/Seq.Api/Model/Events/MessageTemplateTokenPart.cs
+++ b/src/Seq.Api/Model/Events/MessageTemplateTokenPart.cs
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 Datalust and contributors. 
+// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Events/ResultSetPart.cs
+++ b/src/Seq.Api/Model/Events/ResultSetPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Events/ResultSetPart.cs
+++ b/src/Seq.Api/Model/Events/ResultSetPart.cs
@@ -1,11 +1,36 @@
-﻿using System.Collections.Generic;
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
 using Seq.Api.Model.Shared;
 
 namespace Seq.Api.Model.Events
 {
+    /// <summary>
+    /// The result of a request for events matching a filter or signal.
+    /// </summary>
     public class ResultSetPart
     {
+        /// <summary>
+        /// Matching events.
+        /// </summary>
         public List<EventEntity> Events { get; set; }
+
+        /// <summary>
+        /// Statistics describing the server resources used to construct the
+        /// result set.
+        /// </summary>
         public StatisticsPart Statistics { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Expressions/ExpressionPart.cs
+++ b/src/Seq.Api/Model/Expressions/ExpressionPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Expressions/ExpressionPart.cs
+++ b/src/Seq.Api/Model/Expressions/ExpressionPart.cs
@@ -1,9 +1,38 @@
-﻿namespace Seq.Api.Model.Expressions
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Seq.Api.Model.Expressions
 {
+    /// <summary>
+    /// Information about a filter expression.
+    /// </summary>
     public class ExpressionPart
     {
+        /// <summary>
+        /// The expression in strict syntax.
+        /// </summary>
         public string StrictExpression { get; set; }
+
+        /// <summary>
+        /// Whether the expression was considered to be a free text search.
+        /// </summary>
         public bool MatchedAsText { get; set; }
+
+        /// <summary>
+        /// If <see cref="MatchedAsText"/> is <c>true</c>, the reason that the
+        /// expression was not considered a valid structured expression.
+        /// </summary>
         public string ReasonIfMatchedAsText { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Expressions/SqlExpressionPart.cs
+++ b/src/Seq.Api/Model/Expressions/SqlExpressionPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Expressions/SqlExpressionPart.cs
+++ b/src/Seq.Api/Model/Expressions/SqlExpressionPart.cs
@@ -1,7 +1,27 @@
-﻿namespace Seq.Api.Model.Expressions
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Seq.Api.Model.Expressions
 {
+    /// <summary>
+    /// Describes an expression in strict SQL-style syntax.
+    /// </summary>
     public class SqlExpressionPart
     {
+        /// <summary>
+        /// The expression in SQL-style syntax.
+        /// </summary>
         public string Expression { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Feeds/NuGetFeedEntity.cs
+++ b/src/Seq.Api/Model/Feeds/NuGetFeedEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Feeds/NuGetFeedEntity.cs
+++ b/src/Seq.Api/Model/Feeds/NuGetFeedEntity.cs
@@ -1,10 +1,43 @@
-﻿namespace Seq.Api.Model.Feeds
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Seq.Api.Model.Feeds
 {
-    public class NuGetFeedEntity : Seq.Api.Model.Entity
+    /// <summary>
+    /// A NuGet feed.
+    /// </summary>
+    public class NuGetFeedEntity : Entity
     {
+        /// <summary>
+        /// The feed name.
+        /// </summary>
         public string Name { get; set; }
+
+        /// <summary>
+        /// A URI or folder path at which the feed is located.
+        /// </summary>
         public string Location { get; set; }
+
+        /// <summary>
+        /// If required, a username that will be sent when accessing the feed.
+        /// </summary>
         public string Username { get; set; }
+
+        /// <summary>
+        /// When <see cref="Username"/> is non-empty, can be used to set an associated
+        /// password.
+        /// </summary>
         public string NewPassword { get; set; }
     }
 }

--- a/src/Seq.Api/Model/ILinked.cs
+++ b/src/Seq.Api/Model/ILinked.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/ILinked.cs
+++ b/src/Seq.Api/Model/ILinked.cs
@@ -1,7 +1,27 @@
-﻿namespace Seq.Api.Model
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Seq.Api.Model
 {
+    /// <summary>
+    /// A resource that carries outbound links.
+    /// </summary>
     public interface ILinked
     {
+        /// <summary>
+        /// Links associated with the resource.
+        /// </summary>
         LinkCollection Links { get; }
     }
 }

--- a/src/Seq.Api/Model/Inputs/ApiKeyEntity.cs
+++ b/src/Seq.Api/Model/Inputs/ApiKeyEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Inputs/ApiKeyEntity.cs
+++ b/src/Seq.Api/Model/Inputs/ApiKeyEntity.cs
@@ -14,9 +14,7 @@
 
 using System.Collections.Generic;
 using Newtonsoft.Json;
-using Seq.Api.Model.LogEvents;
 using Seq.Api.Model.Security;
-using Seq.Api.Model.Signals;
 
 namespace Seq.Api.Model.Inputs
 {
@@ -33,10 +31,10 @@ namespace Seq.Api.Model.Inputs
         public string Title { get; set; }
 
         /// <summary>
-        /// The API key token. API keys generated for versions of Seq prior to 5.0 will expose this value. From 5.0 onwards,
-        /// <see cref="Token"/> can be specified explicitly when creating an API key, but is not readable once the API key is created.
-        /// Leaving the token blank will cause the server to generate a cryptographically random API key token. After creation, the first
-        /// few characters of the token will be readable from <see cref="TokenPrefix"/>, but because only a cryptographically-secure
+        /// The API key token. <see cref="Token"/> can be specified explicitly when creating an API key, but is not
+        /// readable once the API key is created. Leaving the token blank will cause the server to generate a
+        /// cryptographically random API key token. After creation, the first few (additional, redundant) characters
+        /// of the token will be readable from <see cref="TokenPrefix"/>, but because only a cryptographically-secure
         /// hash of the token is stored internally, the token itself cannot be retrieved.
         /// </summary>
         public string Token { get; set; }
@@ -47,31 +45,12 @@ namespace Seq.Api.Model.Inputs
         public string TokenPrefix { get; set; }
 
         /// <summary>
-        /// Properties that will be automatically added to all events ingested using the key. These will override any properties with
-        /// the same names already present on the event.
+        /// Settings that control how events are ingested through the API key.
         /// </summary>
-        public List<InputAppliedPropertyPart> AppliedProperties { get; set; } = new List<InputAppliedPropertyPart>();
+        public InputSettingsPart InputSettings { get; set; } = new InputSettingsPart();
 
         /// <summary>
-        /// A filter that selects events to ingest. If <c>null</c>, all events received using the key will be ingested.
-        /// </summary>
-        public SignalFilterPart InputFilter { get; set; } = new SignalFilterPart();
-
-        /// <summary>
-        /// A minimum level at which events received using the key will be ingested. The level hierarchy understood by Seq is fuzzy
-        /// enough to handle most common leveling schemes. This value will be provided to callers so that they can dynamically
-        /// filter events client-side, if supported.
-        /// </summary>
-        public LogEventLevel? MinimumLevel { get; set; }
-
-        /// <summary>
-        /// If <c>true</c>, timestamps already present on the events will be ignored, and server timestamps used instead. This is not
-        /// recommended for most use cases.
-        /// </summary>
-        public bool UseServerTimestamps { get; set; }
-
-        /// <summary>
-        /// If <c>true</c>, the key is the built-in (tokenless) API key.
+        /// If <c>true</c>, the key is the built-in (tokenless) API key representing unauthenticated HTTP ingestion.
         /// </summary>
         public bool IsDefault { get; set; }
 
@@ -90,6 +69,6 @@ namespace Seq.Api.Model.Inputs
         /// Information about the ingestion activity using this API key.
         /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public ApiKeyMetricsPart Metrics { get; set; } = new ApiKeyMetricsPart();
+        public InputMetricsPart InputMetrics { get; set; } = new InputMetricsPart();
     }
 }

--- a/src/Seq.Api/Model/Inputs/ApiKeyEntity.cs
+++ b/src/Seq.Api/Model/Inputs/ApiKeyEntity.cs
@@ -1,4 +1,18 @@
-﻿using System.Collections.Generic;
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
 using Newtonsoft.Json;
 using Seq.Api.Model.LogEvents;
 using Seq.Api.Model.Security;
@@ -6,19 +20,75 @@ using Seq.Api.Model.Signals;
 
 namespace Seq.Api.Model.Inputs
 {
+    /// <summary>
+    /// API keys can be used to authenticate and identify log event sources, and for
+    /// users to delegate some or all permissions to a client of the Seq API (app or integration) without exposing
+    /// user credentials.
+    /// </summary>
     public class ApiKeyEntity : Entity
     {
+        /// <summary>
+        /// A friendly human-readable description of the API key.
+        /// </summary>
         public string Title { get; set; }
+
+        /// <summary>
+        /// The API key token. API keys generated for versions of Seq prior to 5.0 will expose this value. From 5.0 onwards,
+        /// <see cref="Token"/> can be specified explicitly when creating an API key, but is not readable once the API key is created.
+        /// Leaving the token blank will cause the server to generate a cryptographically random API key token. After creation, the first
+        /// few characters of the token will be readable from <see cref="TokenPrefix"/>, but because only a cryptographically-secure
+        /// hash of the token is stored internally, the token itself cannot be retrieved.
+        /// </summary>
         public string Token { get; set; }
+
+        /// <summary>
+        /// A few characters from the start of the <see cref="Token"/> stored as plain text, to aid in identifying tokens.
+        /// </summary>
         public string TokenPrefix { get; set; }
+
+        /// <summary>
+        /// Properties that will be automatically added to all events ingested using the key. These will override any properties with
+        /// the same names already present on the event.
+        /// </summary>
         public List<InputAppliedPropertyPart> AppliedProperties { get; set; } = new List<InputAppliedPropertyPart>();
+
+        /// <summary>
+        /// A filter that selects events to ingest. If <c>null</c>, all events received using the key will be ingested.
+        /// </summary>
         public SignalFilterPart InputFilter { get; set; } = new SignalFilterPart();
+
+        /// <summary>
+        /// A minimum level at which events received using the key will be ingested. The level hierarchy understood by Seq is fuzzy
+        /// enough to handle most common leveling schemes. This value will be provided to callers so that they can dynamically
+        /// filter events client-side, if supported.
+        /// </summary>
         public LogEventLevel? MinimumLevel { get; set; }
+
+        /// <summary>
+        /// If <c>true</c>, timestamps already present on the events will be ignored, and server timestamps used instead. This is not
+        /// recommended for most use cases.
+        /// </summary>
         public bool UseServerTimestamps { get; set; }
+
+        /// <summary>
+        /// If <c>true</c>, the key is the built-in (tokenless) API key.
+        /// </summary>
         public bool IsDefault { get; set; }
+
+        /// <summary>
+        /// If non-<c>null</c>, the id of the user for whom this is a personal API key.
+        /// </summary>
         public string OwnerId { get; set; }
+
+        /// <summary>
+        /// The <see cref="Permission"/>s assigned to the API key. Note that, if the API key is owned by an individual user, permissions
+        /// not held by the user will be ignored by the server.
+        /// </summary>
         public HashSet<Permission> AssignedPermissions { get; set; } = new HashSet<Permission>();
 
+        /// <summary>
+        /// Information about the ingestion activity using this API key.
+        /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public ApiKeyMetricsPart Metrics { get; set; } = new ApiKeyMetricsPart();
     }

--- a/src/Seq.Api/Model/Inputs/ApiKeyMetricsPart.cs
+++ b/src/Seq.Api/Model/Inputs/ApiKeyMetricsPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Inputs/ApiKeyMetricsPart.cs
+++ b/src/Seq.Api/Model/Inputs/ApiKeyMetricsPart.cs
@@ -1,9 +1,40 @@
-﻿namespace Seq.Api.Model.Inputs
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Seq.Api.Model.Inputs
 {
+    /// <summary>
+    /// Information about ingestion activity using an API key.
+    /// </summary>
     public class ApiKeyMetricsPart
     {
+        /// <summary>
+        /// The number of events that arrived at the server tagged with this
+        /// key in the past minute.
+        /// </summary>
         public int ArrivalsPerMinute { get; set; }
+
+        /// <summary>
+        /// The number of events that ingested by the server tagged with this
+        /// key in the past minute.
+        /// </summary>
         public int InfluxPerMinute { get; set; }
+        
+        /// <summary>
+        /// The raw JSON bytes (approximate) tagged with this API key that were ingested
+        /// by the server in the past minute.
+        /// </summary>
         public long IngestedBytesPerMinute { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Inputs/InputAppliedPropertyPart.cs
+++ b/src/Seq.Api/Model/Inputs/InputAppliedPropertyPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Inputs/InputAppliedPropertyPart.cs
+++ b/src/Seq.Api/Model/Inputs/InputAppliedPropertyPart.cs
@@ -1,8 +1,33 @@
-﻿namespace Seq.Api.Model.Inputs
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Seq.Api.Model.Inputs
 {
+    /// <summary>
+    /// A name/value property attached to events ingested through an API key.
+    /// </summary>
+    //  Note, this duplicates EventPropertyPart.
     public class InputAppliedPropertyPart
     {
+        /// <summary>
+        /// The property name (required).
+        /// </summary>
         public string Name { get; set; }
+
+        /// <summary>
+        /// The property value, or <c>null</c>.
+        /// </summary>
         public object Value { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Inputs/InputMetricsPart.cs
+++ b/src/Seq.Api/Model/Inputs/InputMetricsPart.cs
@@ -1,0 +1,44 @@
+﻿// Copyright © Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Seq.Api.Model.Inputs
+{
+    /// <summary>
+    /// Information about ingestion activity using an API key.
+    /// </summary>
+    public class InputMetricsPart
+    {
+        /// <summary>
+        /// The number of events that arrived at the server from this input in the past minute.
+        /// </summary>
+        public int ArrivedEventsPerMinute { get; set; }
+
+        /// <summary>
+        /// The number of events that ingested by the server from this input in the past minute.
+        /// </summary>
+        public int IngestedEventsPerMinute { get; set; }
+        
+        /// <summary>
+        /// The raw JSON bytes (approximate) from this input that were ingested
+        /// by the server in the past minute.
+        /// </summary>
+        public long IngestedBytesPerMinute { get; set; }
+        
+        /// <summary>
+        /// The number of invalid payloads reaching this input in the past minute. Invalid payloads includes malformed
+        /// and oversized JSON event bodies, as well as malformed or oversized batches.
+        /// </summary>
+        public long InvalidPayloadsPerMinute { get; set; }
+    }
+}

--- a/src/Seq.Api/Model/Inputs/InputSettingsPart.cs
+++ b/src/Seq.Api/Model/Inputs/InputSettingsPart.cs
@@ -1,0 +1,51 @@
+// Copyright © Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using Seq.Api.Model.LogEvents;
+using Seq.Api.Model.Shared;
+using Seq.Api.Model.Signals;
+
+namespace Seq.Api.Model.Inputs
+{
+    /// <summary>
+    /// Settings carried by API keys, (input) app instances, and other inputs.
+    /// </summary>
+    public class InputSettingsPart
+    {
+        /// <summary>
+        /// Properties that will be automatically added to all events ingested using the key. These will override any properties with
+        /// the same names already present on the event.
+        /// </summary>
+        public List<InputAppliedPropertyPart> AppliedProperties { get; set; } = new List<InputAppliedPropertyPart>();
+
+        /// <summary>
+        /// A filter that selects events to ingest. If <c>null</c>, all events received using the key will be ingested.
+        /// </summary>
+        public DescriptiveFilterPart Filter { get; set; } = new DescriptiveFilterPart();
+
+        /// <summary>
+        /// A minimum level at which events received using the key will be ingested. The level hierarchy understood by Seq is fuzzy
+        /// enough to handle most common leveling schemes. This value will be provided to callers so that they can dynamically
+        /// filter events client-side, if supported.
+        /// </summary>
+        public LogEventLevel? MinimumLevel { get; set; }
+
+        /// <summary>
+        /// If <c>true</c>, timestamps already present on the events will be ignored, and server timestamps used instead. This is not
+        /// recommended for most use cases.
+        /// </summary>
+        public bool UseServerTimestamps { get; set; }
+    }
+}

--- a/src/Seq.Api/Model/License/LicenseEntity.cs
+++ b/src/Seq.Api/Model/License/LicenseEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/License/LicenseEntity.cs
+++ b/src/Seq.Api/Model/License/LicenseEntity.cs
@@ -1,13 +1,60 @@
-﻿namespace Seq.Api.Model.License
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Seq.Api.Model.License
 {
+    /// <summary>
+    /// A Seq license certificate.
+    /// </summary>
     public class LicenseEntity : Entity
     {
+        /// <summary>
+        /// The cryptographically-signed certificate that describes the
+        /// license, or <c>null</c> if the server is using the default license.
+        /// </summary>
         public string LicenseText { get; set; }
+
+        /// <summary>
+        /// Whether or not the license is valid for the server.
+        /// </summary>
         public bool IsValid { get; set; }
+
+        /// <summary>
+        /// If <c>true</c>, the server is using the default license which allows
+        /// a single person to access the Seq server.
+        /// </summary>
         public bool IsSingleUser { get; set; }
+
+        /// <summary>
+        /// Information about the status of the license.
+        /// </summary>
         public string StatusDescription { get; set; }
+
+        /// <summary>
+        /// If <c>true</c>, see <see cref="StatusDescription"/> for important information.
+        /// </summary>
         public bool IsWarning { get; set; }
+
+        /// <summary>
+        /// If <c>true</c>, the license can be renewed online.
+        /// </summary>
         public bool CanRenewOnlineNow { get; set; }
+
+        /// <summary>
+        /// The number of users licensed to access the Seq server, or <c>null</c> if
+        /// the license has no user limit.
+        /// </summary>
         public int? LicensedUsers { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Link.cs
+++ b/src/Seq.Api/Model/Link.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Link.cs
+++ b/src/Seq.Api/Model/Link.cs
@@ -1,49 +1,80 @@
-﻿using System;
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using Tavis.UriTemplates;
+
+// ReSharper disable PossibleMultipleEnumeration
 
 namespace Seq.Api.Model
 {
-    public class Link
+    /// <summary>
+    /// A hypermedia link. A link is an RFC 6570 URI template that can be
+    /// parameterized in order to produce a complete URI (if the template contains no
+    /// parameters then it may also be a literal URI).
+    /// </summary>
+    public struct Link
     {
-        readonly bool _isLiteral;
-        readonly string _href;
-        readonly IDictionary<string, object> _parameters;
+        /// <summary>
+        /// An empty link.
+        /// </summary>
+        public static Link Empty { get; } = default;
 
-        public Link(string href, bool isLiteral = true)
-            : this(href, new Dictionary<string, object>())
+        /// <summary>
+        /// Construct a link.
+        /// </summary>
+        /// <param name="template">The URI template.</param>
+        public Link(string template)
         {
-            _isLiteral = isLiteral;
+            Template = template ?? throw new ArgumentNullException(nameof(template));
         }
 
-        public Link(string href, IDictionary<string, object> parameters)
-        {
-            if (href == null) throw new ArgumentNullException(nameof(href));
-            if (parameters == null) throw new ArgumentNullException(nameof(parameters));
-            _href = href;
-            _parameters = parameters;
-        }
+        /// <summary>
+        /// Get the unprocessed URI template.
+        /// </summary>
+        public string Template { get; }
 
-        public Link(string href, object parameters)
-            : this(href, parameters
-                .GetType()
-                .GetTypeInfo()
-                .DeclaredProperties
-                .ToDictionary(p => p.Name, p => p.GetValue(parameters)))
+        /// <summary>
+        /// Parameterize the link to construct a URI.
+        /// </summary>
+        /// <param name="parameters">Parameters to substitute into the template, if any.</param>
+        /// <returns>A constructed URI.</returns>
+        /// <remarks>This method ensures that templates containing parameters cannot be accidentally
+        /// used as URIs.</remarks>
+        public string GetUri(IDictionary<string, object> parameters = null)
         {
-        }
+            if (Template == null) throw new InvalidOperationException("Attempted to process an empty URI template.");
 
-        public string GetUri()
-        {
-            if (_isLiteral) return _href;
-
-            var template = new UriTemplate(_href);
-            foreach (var parameter in _parameters)
+            var template = new UriTemplate(Template);
+            if (parameters != null)
             {
-                template.SetParameter(parameter.Key, parameter.Value);
+                var missing = parameters.Select(p => p.Key).Except(template.GetParameterNames());
+                if (missing.Any())
+                    throw new ArgumentException($"The URI template `{Template}` does not contain parameter: `{string.Join("`, `", missing)}`.");
+
+                foreach (var parameter in parameters)
+                {
+                    var value = parameter.Value is DateTime time
+                        ? time.ToString("O")
+                        : parameter.Value;
+
+                    template.SetParameter(parameter.Key, value);
+                }
             }
+
             return template.Resolve();
         }
     }

--- a/src/Seq.Api/Model/LinkCollection.cs
+++ b/src/Seq.Api/Model/LinkCollection.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/LinkCollection.cs
+++ b/src/Seq.Api/Model/LinkCollection.cs
@@ -1,18 +1,30 @@
-﻿using System;
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using Seq.Api.Serialization;
 
 namespace Seq.Api.Model
 {
+    /// <summary>
+    /// A collection of <see cref="Link"/>s indexed by case-insensitive name.
+    /// </summary>
     [JsonConverter(typeof(LinkCollectionConverter))]
     public class LinkCollection : Dictionary<string, Link>
     {
         public LinkCollection() : base(StringComparer.OrdinalIgnoreCase) { }
-
-        public string GetUri(string name)
-        {
-            return this[name].GetUri();
-        }
     }
 }

--- a/src/Seq.Api/Model/LinkCollection.cs
+++ b/src/Seq.Api/Model/LinkCollection.cs
@@ -25,6 +25,9 @@ namespace Seq.Api.Model
     [JsonConverter(typeof(LinkCollectionConverter))]
     public class LinkCollection : Dictionary<string, Link>
     {
+        /// <summary>
+        /// Construct a <see cref="LinkCollection"/>.
+        /// </summary>
         public LinkCollection() : base(StringComparer.OrdinalIgnoreCase) { }
     }
 }

--- a/src/Seq.Api/Model/LogEvents/LogEventLevel.cs
+++ b/src/Seq.Api/Model/LogEvents/LogEventLevel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/LogEvents/LogEventLevel.cs
+++ b/src/Seq.Api/Model/LogEvents/LogEventLevel.cs
@@ -1,4 +1,18 @@
-﻿namespace Seq.Api.Model.LogEvents
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Seq.Api.Model.LogEvents
 {
     /// <summary>
     /// Specifies the meaning and relative importance of a log event.

--- a/src/Seq.Api/Model/Monitoring/AlertPart.cs
+++ b/src/Seq.Api/Model/Monitoring/AlertPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Monitoring/AlertPart.cs
+++ b/src/Seq.Api/Model/Monitoring/AlertPart.cs
@@ -1,22 +1,78 @@
-﻿using Seq.Api.Model.LogEvents;
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Seq.Api.Model.LogEvents;
 using System;
 using System.Collections.Generic;
+using Seq.Api.Model.AppInstances;
 
 namespace Seq.Api.Model.Monitoring
 {
+    /// <summary>
+    /// An alert attached to a dashboard chart.
+    /// </summary>
     public class AlertPart
     {
         Dictionary<string, string> _notificationAppSettingOverrides = new Dictionary<string, string>();
 
+        /// <summary>
+        /// The unique id assigned to the alert.
+        /// </summary>
         public string Id { get; set; }
+
+        /// <summary>
+        /// The alert condition. This is effectively a <c>having</c> clause over the grouped results
+        /// computed by the <see cref="ChartQueryPart"/>.
+        /// </summary>
         public string Condition { get; set; }
+
+        /// <summary>
+        /// A friendly, human-readable description of the alert.
+        /// </summary>
         public string Title { get; set; }
+
+        /// <summary>
+        /// The interval within which the alert condition will be measured.
+        /// </summary>
         public TimeSpan MeasurementWindow { get; set; }
+
+        /// <summary>
+        /// The time allowed for events to reach the server before being included in alert calculations.
+        /// This is relative to the current server clock.
+        /// </summary>
         public TimeSpan StabilizationWindow { get; set; } = TimeSpan.FromSeconds(30);
+
+        /// <summary>
+        /// The time after the alert files within which no further notifications will be sent for the
+        /// alert.
+        /// </summary>
         public TimeSpan SuppressionTime { get; set; }
+
+        /// <summary>
+        /// An informational level that suggests the importance of the alert.
+        /// </summary>
         public LogEventLevel Level { get; set; } = LogEventLevel.Warning;
+
+        /// <summary>
+        /// The id of an <see cref="AppInstanceEntity"/> that will receive notifications from the alert.
+        /// </summary>
         public string NotificationAppInstanceId { get; set; }
 
+        /// <summary>
+        /// Additional properties that will be used to configure the notification app when triggered
+        /// by the alert.
+        /// </summary>
         public Dictionary<string, string> NotificationAppSettingOverrides
         {
             get => _notificationAppSettingOverrides;

--- a/src/Seq.Api/Model/Monitoring/AlertStateEntity.cs
+++ b/src/Seq.Api/Model/Monitoring/AlertStateEntity.cs
@@ -1,0 +1,79 @@
+﻿// Copyright Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace Seq.Api.Model.Monitoring
+{
+    /// <summary>
+    /// Describes the state of an active alert.
+    /// </summary>
+    public class AlertStateEntity : Entity
+    {
+        /// <summary>
+        /// The unique id of the alert being described.
+        /// </summary>
+        public string AlertId { get; set; }
+        
+        /// <summary>
+        /// The alert's title.
+        /// </summary>
+        public string Title { get; set; }
+        
+        /// <summary>
+        /// The title of the chart to which the alert is attached.
+        /// </summary>
+        public string ChartTitle { get; set; }
+        
+        /// <summary>
+        /// The title of the dashboards in which the alert is set.
+        /// </summary>
+        public string DashboardTitle { get; set; }
+
+        /// <summary>
+        /// The user id of the user who owns the alert; if <c>null</c>, the alert is shared.
+        /// </summary>
+        public string OwnerId { get; set; }
+
+        /// <summary>
+        /// The notification level associated with the alert.
+        /// </summary>
+        public string Level { get; set; }
+        
+        /// <summary>
+        /// The id of an app instance that will receive notifications when the alert is triggered.
+        /// </summary>
+        public string NotificationAppInstanceId { get; set; }
+
+        /// <summary>
+        /// The time at which the alert was last checked. Not preserved across server restarts.
+        /// </summary>
+        public DateTime? LastCheck { get; set; }
+
+        /// <summary>
+        /// The time at which the alert last triggered a notification. Not preserved across server restarts.
+        /// </summary>
+        public DateTime? LastNotification { get; set; }
+        
+        /// <summary>
+        /// The time until which no further notifications will be sent by the alert.
+        /// </summary>
+        public DateTime? SuppressedUntil { get; set; }
+        
+        /// <summary>
+        /// <c>true</c> if the alert is in the failing state; otherwise, <c>false</c>.
+        /// </summary>
+        public bool IsFailing { get; set; }
+    }
+}

--- a/src/Seq.Api/Model/Monitoring/ChartDisplayStylePart.cs
+++ b/src/Seq.Api/Model/Monitoring/ChartDisplayStylePart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Monitoring/ChartDisplayStylePart.cs
+++ b/src/Seq.Api/Model/Monitoring/ChartDisplayStylePart.cs
@@ -1,8 +1,32 @@
-﻿namespace Seq.Api.Model.Monitoring
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Seq.Api.Model.Monitoring
 {
+    /// <summary>
+    /// How a chart will be displayed on a dashboard.
+    /// </summary>
     public class ChartDisplayStylePart
     {
+        /// <summary>
+        /// The width of the chart, in 1/12th columns.
+        /// </summary>
         public int WidthColumns { get; set; } = 6;
+
+        /// <summary>
+        /// The height of the chart, in rows.
+        /// </summary>
         public int HeightRows { get; set; } = 1;
     }
 }

--- a/src/Seq.Api/Model/Monitoring/ChartPart.cs
+++ b/src/Seq.Api/Model/Monitoring/ChartPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Monitoring/ChartPart.cs
+++ b/src/Seq.Api/Model/Monitoring/ChartPart.cs
@@ -1,14 +1,51 @@
-﻿using System.Collections.Generic;
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
 using Seq.Api.Model.Signals;
 
 namespace Seq.Api.Model.Monitoring
 {
+    /// <summary>
+    /// A chart that appears on a dashboard.
+    /// </summary>
     public class ChartPart
     {
+        /// <summary>
+        /// The unique id assigned to the chart.
+        /// </summary>
         public string Id { get; set; }
+
+        /// <summary>
+        /// A human-friendly title for the chart.
+        /// </summary>
         public string Title { get; set; }
+
+        /// <summary>
+        /// An optional <see cref="SignalExpressionPart"/> that limits what data the chart will display.
+        /// </summary>
         public SignalExpressionPart SignalExpression { get; set; }
+
+        /// <summary>
+        /// The individual queries making up the chart. In most instances, only one query is currently supported
+        /// here.
+        /// </summary>
         public List<ChartQueryPart> Queries { get; set; } = new List<ChartQueryPart>();
+
+        /// <summary>
+        /// How the chart will appear on the dashboard.
+        /// </summary>
         public ChartDisplayStylePart DisplayStyle { get; set; } = new ChartDisplayStylePart();
     }
 }

--- a/src/Seq.Api/Model/Monitoring/ChartQueryPart.cs
+++ b/src/Seq.Api/Model/Monitoring/ChartQueryPart.cs
@@ -1,19 +1,75 @@
-﻿using System.Collections.Generic;
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
 using Seq.Api.Model.Signals;
 
 namespace Seq.Api.Model.Monitoring
 {
+    /// <summary>
+    /// A query within a chart.
+    /// </summary>
     public class ChartQueryPart
     {
+        /// <summary>
+        /// The unique id assigned to the query.
+        /// </summary>
         public string Id { get; set; }
+
+        /// <summary>
+        /// Individual measurements included in the query. These are effectively projected columns.
+        /// </summary>
         public List<MeasurementPart> Measurements { get; set; } = new List<MeasurementPart>();
+
+        /// <summary>
+        /// An optional filtering <c>where</c> clause limiting the data that contributes to the chart.
+        /// </summary>
         public string Where { get; set; }
+
+        /// <summary>
+        /// An optional <see cref="SignalExpressionPart"/> limiting the data that contributes to the chart.
+        /// </summary>
         public SignalExpressionPart SignalExpression { get; set; }
+
+        /// <summary>
+        /// A series of expressions used to group data returned by the query.
+        /// </summary>
         public List<string> GroupBy { get; set; } = new List<string>();
+
+        /// <summary>
+        /// How measurements included in the chart will be displayed.
+        /// </summary>
         public MeasurementDisplayStylePart DisplayStyle { get; set; } = new MeasurementDisplayStylePart();
+
+        /// <summary>
+        /// Alerts attached to the chart.
+        /// </summary>
         public List<AlertPart> Alerts { get; set; } = new List<AlertPart>();
+
+        /// <summary>
+        /// A filter that limits which groups will be displayed on the chart. Not supported by all chart types.
+        /// </summary>
         public string Having { get; set; }
+
+        /// <summary>
+        /// An ordering applied to the results of the query; not supported by all chart types.
+        /// </summary>
         public List<string> OrderBy { get; set; } = new List<string>();
+
+        /// <summary>
+        /// The row limit used for the query. By default, a server-determined limit will be applied.
+        /// </summary>
         public int? Limit { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Monitoring/ChartQueryPart.cs
+++ b/src/Seq.Api/Model/Monitoring/ChartQueryPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Monitoring/DashboardEntity.cs
+++ b/src/Seq.Api/Model/Monitoring/DashboardEntity.cs
@@ -1,18 +1,51 @@
-﻿using System.Collections.Generic;
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using Seq.Api.Model.Security;
 using Seq.Api.Model.Signals;
 
 namespace Seq.Api.Model.Monitoring
 {
+    /// <summary>
+    /// A dashboard.
+    /// </summary>
     public class DashboardEntity : Entity
     {
+        /// <summary>
+        /// The user who owns the dashboard. If <c>null</c>, the dashboard is shared.
+        /// </summary>
         public string OwnerId { get; set; }
 
+        /// <summary>
+        /// The friendly, human-readable title for the dashboard.
+        /// </summary>
         public string Title { get; set; }
 
+        /// <summary>
+        /// If <c>true</c>, only users with <see cref="Permission.Setup"/> can modify the dashboard.
+        /// </summary>
         public bool IsProtected { get; set; }
 
+        /// <summary>
+        /// An optional <see cref="SignalExpressionPart"/> that limits the data contributing to the dashboard.
+        /// </summary>
         public SignalExpressionPart SignalExpression { get; set; }
 
+        /// <summary>
+        /// The list of charts included in the dashboard.
+        /// </summary>
         public List<ChartPart> Charts { get; set; } = new List<ChartPart>();
     }
 }

--- a/src/Seq.Api/Model/Monitoring/DashboardEntity.cs
+++ b/src/Seq.Api/Model/Monitoring/DashboardEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Monitoring/MeasurementDisplayPalette.cs
+++ b/src/Seq.Api/Model/Monitoring/MeasurementDisplayPalette.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Monitoring/MeasurementDisplayPalette.cs
+++ b/src/Seq.Api/Model/Monitoring/MeasurementDisplayPalette.cs
@@ -1,11 +1,47 @@
-﻿namespace Seq.Api.Model.Monitoring
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Seq.Api.Model.Monitoring
 {
+    /// <summary>
+    /// The color palette used for displaying a measurement on a chart.
+    /// </summary>
     public enum MeasurementDisplayPalette
     {
+        /// <summary>
+        /// The default palette.
+        /// </summary>
         Default,
+
+        /// <summary>
+        /// A predominantly red palette.
+        /// </summary>
         Reds,
+
+        /// <summary>
+        /// A predominantly green palette.
+        /// </summary>
         Greens,
+
+        /// <summary>
+        /// A predominantly blue palette.
+        /// </summary>
         Blues,
+
+        /// <summary>
+        /// An orange/purple palette.
+        /// </summary>
         OrangePurple
     }
 }

--- a/src/Seq.Api/Model/Monitoring/MeasurementDisplayStylePart.cs
+++ b/src/Seq.Api/Model/Monitoring/MeasurementDisplayStylePart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Monitoring/MeasurementDisplayStylePart.cs
+++ b/src/Seq.Api/Model/Monitoring/MeasurementDisplayStylePart.cs
@@ -1,12 +1,52 @@
-﻿namespace Seq.Api.Model.Monitoring
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Seq.Api.Model.Monitoring
 {
+    /// <summary>
+    /// How a measurement will be displayed within a chart.
+    /// </summary>
     public class MeasurementDisplayStylePart
     {
+        /// <summary>
+        /// The type of display used for the measurement.
+        /// </summary>
         public MeasurementDisplayType Type { get; set; } = MeasurementDisplayType.Line;
+
+        /// <summary>
+        /// For line chart measurement display types, whether the area under the line will be filled.
+        /// </summary>
         public bool LineFillToZeroY { get; set; }
+
+        /// <summary>
+        /// For line chart measurement display types, whether the points along the line will be visibly marked.
+        /// </summary>
         public bool LineShowMarkers { get; set; } = true;
+
+        /// <summary>
+        /// For bar chart measurement display types, whether the sum of all bars will be shown as an overlay.
+        /// </summary>
         public bool BarOverlaySum { get; set; }
+
+        /// <summary>
+        /// For measurement display types that include a legend, whether the legend will be shown.
+        /// </summary>
         public bool SuppressLegend { get; set; }
+
+        /// <summary>
+        /// The color palette used to display the chart.
+        /// </summary>
         public MeasurementDisplayPalette Palette { get; set; } = MeasurementDisplayPalette.Default;
     }
 }

--- a/src/Seq.Api/Model/Monitoring/MeasurementDisplayType.cs
+++ b/src/Seq.Api/Model/Monitoring/MeasurementDisplayType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Monitoring/MeasurementDisplayType.cs
+++ b/src/Seq.Api/Model/Monitoring/MeasurementDisplayType.cs
@@ -1,12 +1,52 @@
-﻿namespace Seq.Api.Model.Monitoring
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Seq.Api.Model.Monitoring
 {
+    /// <summary>
+    /// The method used to visually represent a measurement.
+    /// </summary>
     public enum MeasurementDisplayType
     {
+        /// <summary>
+        /// A line chart. Requires the measurement and query to include a time axis.
+        /// </summary>
         Line,
+
+        /// <summary>
+        /// A bar chart.
+        /// </summary>
         Bar,
+
+        /// <summary>
+        /// A point (scatter) chart.
+        /// </summary>
         Point,
+
+        /// <summary>
+        /// A single textual value. Requires that the measurement and query produce a single value.
+        /// </summary>
         Value,
+
+        /// <summary>
+        /// A (donut-styled) pie chart.
+        /// </summary>
         Pie,
+
+        /// <summary>
+        /// A table of raw data values.
+        /// </summary>
         Table
     }
 }

--- a/src/Seq.Api/Model/Monitoring/MeasurementPart.cs
+++ b/src/Seq.Api/Model/Monitoring/MeasurementPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Monitoring/MeasurementPart.cs
+++ b/src/Seq.Api/Model/Monitoring/MeasurementPart.cs
@@ -1,8 +1,32 @@
-﻿namespace Seq.Api.Model.Monitoring
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Seq.Api.Model.Monitoring
 {
+    /// <summary>
+    /// A measurement that contributes to a chart.
+    /// </summary>
     public class MeasurementPart
     {
+        /// <summary>
+        /// The expression (<c>select</c>ed column) that computes the value of the measurement.
+        /// </summary>
         public string Value { get; set; }
+
+        /// <summary>
+        /// An optional label for the measurement (effectively the right-hand size of an <c>as</c> clause).
+        /// </summary>
         public string Label { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Permalinks/PermalinkEntity.cs
+++ b/src/Seq.Api/Model/Permalinks/PermalinkEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Permalinks/PermalinkEntity.cs
+++ b/src/Seq.Api/Model/Permalinks/PermalinkEntity.cs
@@ -1,21 +1,54 @@
-﻿using System;
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using Newtonsoft.Json;
 using Seq.Api.Model.Events;
+using Seq.Api.ResourceGroups;
 
 namespace Seq.Api.Model.Permalinks
 {
+    /// <summary>
+    /// A permanently preserved event with a stable URI.
+    /// </summary>
     public class PermalinkEntity : Entity
     {
         /// <summary>
-        /// When retrieving an event that _may_ be permalinked (backwards compatibility),
-        /// this hint is given by specifiying `permalinkId=unknown` in the API call.
+        /// When retrieving an event that <em>may</em> be permalinked (backwards compatibility),
+        /// this hint is given by specifying `permalinkId=unknown` in the API call.
         /// </summary>
         public const string UnknownId = "unknown";
 
+        /// <summary>
+        /// The owner of the permalink.
+        /// </summary>
         public string OwnerId { get; set; }
+
+        /// <summary>
+        /// The original id of the permalinked event.
+        /// </summary>
         public string EventId { get; set; }
+
+        /// <summary>
+        /// When the permalink was created.
+        /// </summary>
         public DateTime CreatedUtc { get; set; }
 
+        /// <summary>
+        /// The event itself. Only populated when explicitly requested from the API.
+        /// See <see cref="PermalinksResourceGroup.FindAsync"/>.
+        /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public EventEntity Event { get; set; }
     }

--- a/src/Seq.Api/Model/ResourceGroup.cs
+++ b/src/Seq.Api/Model/ResourceGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/ResourceGroup.cs
+++ b/src/Seq.Api/Model/ResourceGroup.cs
@@ -1,12 +1,34 @@
-﻿namespace Seq.Api.Model
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Seq.Api.Model
 {
+    /// <summary>
+    /// A resource group is a logical partitioning of the API, usually
+    /// associated with a particular type of entity.
+    /// </summary>
     public class ResourceGroup : ILinked
     {
+        /// <summary>
+        /// Construct a <see cref="ResourceGroup"/>.
+        /// </summary>
         public ResourceGroup()
         {
             Links = new LinkCollection();
         }
 
+        /// <inheritdoc/>
         public LinkCollection Links { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Retention/RetentionPolicyEntity.cs
+++ b/src/Seq.Api/Model/Retention/RetentionPolicyEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Retention/RetentionPolicyEntity.cs
+++ b/src/Seq.Api/Model/Retention/RetentionPolicyEntity.cs
@@ -1,14 +1,43 @@
-﻿using System;
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using Seq.Api.Model.Signals;
 
 namespace Seq.Api.Model.Retention
 {
+    /// <summary>
+    /// A retention policy. Identifies a subset of events to delete at a specified age.
+    /// </summary>
     public class RetentionPolicyEntity : Entity
     {
+        /// <summary>
+        /// The age at which events will be deleted by the policy. This is based on the
+        /// events' timestamps relative to the server's clock.
+        /// </summary>
         public TimeSpan RetentionTime { get; set; }
 
+        /// <summary>
+        /// An optional <see cref="SignalExpressionPart"/> describing the set of events
+        /// to delete. If <c>null</c>, the policy will efficiently truncate the event store,
+        /// deleting all events.
+        /// </summary>
         public SignalExpressionPart RemovedSignalExpression { get; set; }
 
+        /// <summary>
+        /// Obsolete.
+        /// </summary>
         [Obsolete("Replaced by RemovedSignalExpression.")]
         public string SignalId { get; set; }
     }

--- a/src/Seq.Api/Model/Root/RootEntity.cs
+++ b/src/Seq.Api/Model/Root/RootEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Root/RootEntity.cs
+++ b/src/Seq.Api/Model/Root/RootEntity.cs
@@ -1,15 +1,50 @@
-﻿namespace Seq.Api.Model.Root
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Seq.Api.Model.Root
 {
+    /// <summary>
+    /// Information about the API exposed by the server.
+    /// </summary>
     public class RootEntity : ILinked
     {
+        /// <summary>
+        /// Construct a <see cref="RootEntity"/>.
+        /// </summary>
         public RootEntity()
         {
             Links = new LinkCollection();
         }
 
+        /// <summary>
+        /// The product serving the API.
+        /// </summary>
         public string Product { get; set; }
+
+        /// <summary>
+        /// The version of the product serving the API.
+        /// </summary>
         public string Version { get; set; }
+
+        /// <summary>
+        /// An informational name identifying the instance.
+        /// </summary>
         public string InstanceName { get; set; }
+
+        /// <summary>
+        /// Links to resources exposed by the API.
+        /// </summary>
         public LinkCollection Links { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Security/Permission.cs
+++ b/src/Seq.Api/Model/Security/Permission.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Security/Permission.cs
+++ b/src/Seq.Api/Model/Security/Permission.cs
@@ -1,4 +1,18 @@
-﻿namespace Seq.Api.Model.Security
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Seq.Api.Model.Security
 {
     /// <summary>
     /// A permission is an access right 1) held by a principal, and 2) demanded by an endpoint. Permissions

--- a/src/Seq.Api/Model/Security/RoleEntity.cs
+++ b/src/Seq.Api/Model/Security/RoleEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Security/RoleEntity.cs
+++ b/src/Seq.Api/Model/Security/RoleEntity.cs
@@ -1,10 +1,34 @@
-﻿using System.Collections.Generic;
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
 
 namespace Seq.Api.Model.Security
 {
+    /// <summary>
+    /// A role is a set of permissions designed to support a particular type of user.
+    /// </summary>
     public class RoleEntity : Entity
     {
+        /// <summary>
+        /// The name of the role.
+        /// </summary>
         public string Title { get; set; }
+
+        /// <summary>
+        /// Permissions granted to users in the role.
+        /// </summary>
         public HashSet<Permission> Permissions { get; set; } = new HashSet<Permission>();
     }
 }

--- a/src/Seq.Api/Model/Security/WellKnownRole.cs
+++ b/src/Seq.Api/Model/Security/WellKnownRole.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Security/WellKnownRole.cs
+++ b/src/Seq.Api/Model/Security/WellKnownRole.cs
@@ -1,11 +1,35 @@
-﻿using System;
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 
 namespace Seq.Api.Model.Security
 {
+    /// <summary>
+    /// Obsolete.
+    /// </summary>
     [Obsolete("It's recommended that new code look up roles by name in `SeqConnection.Roles`.")]
     public static class WellKnownRole
     {
+        /// <summary>
+        /// Obsolete.
+        /// </summary>
         public const string AdministratorRoleId = "role-administrator";
+
+        /// <summary>
+        /// Obsolete.
+        /// </summary>
         public const string UserRoleId = "role-user";
     }
 }

--- a/src/Seq.Api/Model/Security/WellKnownRole.cs
+++ b/src/Seq.Api/Model/Security/WellKnownRole.cs
@@ -1,5 +1,8 @@
-﻿namespace Seq.Api.Model.Security
+﻿using System;
+
+namespace Seq.Api.Model.Security
 {
+    [Obsolete("It's recommended that new code look up roles by name in `SeqConnection.Roles`.")]
     public static class WellKnownRole
     {
         public const string AdministratorRoleId = "role-administrator";

--- a/src/Seq.Api/Model/Settings/InternalErrorReportingSettingsPart.cs
+++ b/src/Seq.Api/Model/Settings/InternalErrorReportingSettingsPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Settings/InternalErrorReportingSettingsPart.cs
+++ b/src/Seq.Api/Model/Settings/InternalErrorReportingSettingsPart.cs
@@ -1,8 +1,35 @@
-﻿namespace Seq.Api.Model.Settings
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Seq.Api.Model.Settings
 {
+    /// <summary>
+    /// Settings for internal error reporting.
+    /// </summary>
     public class InternalErrorReportingSettingsPart
     {
+        /// <summary>
+        /// If <c>true</c>, redacted internal error reports will be sent
+        /// automatically to Datalust.
+        /// </summary>
         public bool InternalErrorReportingEnabled { get; set; }
+
+        /// <summary>
+        /// If internal error reporting is enabled, an optional email address
+        /// that will be attached to error reports so that the support team
+        /// at Datalust can respond with fix/mitigation information.
+        /// </summary>
         public string ReplyEmail { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Settings/SettingEntity.cs
+++ b/src/Seq.Api/Model/Settings/SettingEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Settings/SettingEntity.cs
+++ b/src/Seq.Api/Model/Settings/SettingEntity.cs
@@ -1,8 +1,35 @@
-﻿namespace Seq.Api.Model.Settings
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Seq.Api.Model.Settings
 {
+    /// <summary>
+    /// A Seq system-level setting. Note that only runtime-modifiable
+    /// settings are exposed this way. Other configuration options are
+    /// set using the Seq server command-line.
+    /// </summary>
     public class SettingEntity : Entity
     {
+        /// <summary>
+        /// The name of the setting. See <see cref="SettingName"/> for a selection
+        /// of current values.
+        /// </summary>
         public string Name { get; set; }
+
+        /// <summary>
+        /// The value of the setting.
+        /// </summary>
         public object Value { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Settings/SettingName.cs
+++ b/src/Seq.Api/Model/Settings/SettingName.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -109,6 +109,11 @@ namespace Seq.Api.Model.Settings
         /// Seq will stop accepting new events.
         /// </summary>
         MinimumFreeStorageSpace,
+
+        /// <summary>
+        /// A comma-separated list of role ids that will be assigned to new users by default.
+        /// </summary>
+        NewUserRoleIds,
 
         /// <summary>
         /// A comma-separated list of (shared) signal ids that will be included in any new user's

--- a/src/Seq.Api/Model/Settings/SettingName.cs
+++ b/src/Seq.Api/Model/Settings/SettingName.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using Seq.Api.Model.Apps;
 using Seq.Api.Model.Updates;
 using Seq.Api.ResourceGroups;
@@ -25,6 +26,12 @@ namespace Seq.Api.Model.Settings
     public enum SettingName
     {
         /// <summary>
+        /// The authentication provider to use. Allowed values are <c>null</c> (local username/password),
+        /// <c>"Active Directory"</c>, <c>"Azure Active Directory"</c> and <c>"OpenID Connect"</c>.
+        /// </summary>
+        AuthenticationProvider,
+        
+        /// <summary>
         /// The name of an Active Directory group within which users will be automatically
         /// be granted user access to Seq.
         /// </summary>
@@ -34,8 +41,21 @@ namespace Seq.Api.Model.Settings
         /// If <c>true</c>, Azure Active Directory accounts in the configured tenant will
         /// be automatically granted user access to Seq.
         /// </summary>
+        [Obsolete("Use `AutomaticallyProvisionAuthenticatedUsers`.", error: true)]
         AutomaticallyGrantUserAccessToADAccounts,
+        
+        /// <summary>
+        /// If <c>true</c>, users authenticated with the configured authentication provider
+        /// be automatically granted default user access to Seq.
+        /// </summary>
+        AutomaticallyProvisionAuthenticatedUsers,
 
+        /// <summary>
+        /// The AAD authority. The default is <c>login.windows.net</c>; government cloud users may
+        /// require <c>login.microsoftonline.us</c> or similar.
+        /// </summary>
+        AzureADAuthority,
+        
         /// <summary>
         /// The Azure Active Directory client id.
         /// </summary>
@@ -87,17 +107,13 @@ namespace Seq.Api.Model.Settings
         /// <summary>
         /// If <c>true</c>, the server supports Active Directory authentication.
         /// </summary>
+        [Obsolete("Set `AuthenticationProvider` to \"Active Directory\" to enable.", error: true)]
         IsActiveDirectoryAuthentication,
 
         /// <summary>
         /// If <c>true</c>, the server has authentication enabled.
         /// </summary>
         IsAuthenticationEnabled,
-
-        /// <summary>
-        /// Obsolete.
-        /// </summary>
-        LazilyFlushEventWrites,
 
         /// <summary>
         /// Tracks whether an admin user has dismissed the master key backup warning.
@@ -133,6 +149,28 @@ namespace Seq.Api.Model.Settings
         /// </summary>
         NewUserShowDashboardIds,
 
+        /// <summary>
+        /// If using OpenID Connect authentication, the URL of the authorization endpoint. For example,
+        /// <c>https://example.com</c>.
+        /// </summary>
+        OpenIdConnectAuthority,
+        
+        /// <summary>
+        /// If using OpenID Connect, the client id assigned to Seq in the provider.
+        /// </summary>
+        OpenIdConnectClientId,
+        
+        /// <summary>
+        /// If using OpenID Connect, the client secret assigned to Seq in the provider.
+        /// </summary>
+        OpenIdConnectClientSecret,
+
+        /// <summary>
+        /// If using OpenID Connect, the scopes Seq will request when authorizing the client, as a comma-separated
+        /// list. For example, <c>openid, profile, email</c>.
+        /// </summary>
+        OpenIdConnectScopes,
+    
         /// <summary>
         /// If <c>true</c>, ingestion requests incoming via HTTP must be authenticated using an API key or
         /// logged-in user session. Only effective when <see cref="IsAuthenticationEnabled"/> is <c>true</c>.

--- a/src/Seq.Api/Model/Settings/SettingName.cs
+++ b/src/Seq.Api/Model/Settings/SettingName.cs
@@ -1,29 +1,152 @@
-﻿namespace Seq.Api.Model.Settings
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Seq.Api.Model.Apps;
+using Seq.Api.Model.Updates;
+using Seq.Api.ResourceGroups;
+
+namespace Seq.Api.Model.Settings
 {
+    /// <summary>
+    /// Runtime-modifiable setting names. See also <see cref="SettingEntity"/> and
+    /// <see cref="SettingsResourceGroup"/>.
+    /// </summary>
     public enum SettingName
     {
+        /// <summary>
+        /// The name of an Active Directory group within which users will be automatically
+        /// be granted user access to Seq.
+        /// </summary>
         AutomaticAccessADGroup,
+
+        /// <summary>
+        /// If <c>true</c>, Azure Active Directory accounts in the configured tenant will
+        /// be automatically granted user access to Seq.
+        /// </summary>
         AutomaticallyGrantUserAccessToADAccounts,
+
+        /// <summary>
+        /// The Azure Active Directory client id.
+        /// </summary>
         AzureADClientId,
+
+        /// <summary>
+        /// The Azure Active Directory client key.
+        /// </summary>
         AzureADClientKey,
+
+        /// <summary>
+        /// The Azure Active Directory tenant id.
+        /// </summary>
         AzureADTenantId,
+
+        /// <summary>
+        /// Server-local filesystem location where automatic backups are stored.
+        /// </summary>
         BackupLocation,
+
+        /// <summary>
+        /// The number of backups to keep.
+        /// </summary>
         BackupsToKeep,
+
+        /// <summary>
+        /// The UTC time of day to record new backups.
+        /// </summary>
         BackupUtcTimeOfDay,
+
+        /// <summary>
+        /// If <c>true</c>, Seq will periodically check configured NuGet feed for
+        /// updated versions of installed app packages, and
+        /// set <see cref="AppPackagePart.UpdateAvailable"/> accordingly.
+        /// </summary>
         CheckForPackageUpdates,
+
+        /// <summary>
+        /// If <c>true</c>, Seq will periodically check for new Seq versions, and
+        /// create an <see cref="AvailableUpdateEntity"/> accordingly.
+        /// </summary>
         CheckForUpdates,
+
+        /// <summary>
+        /// A friendly, public, human-readable title identifying this particular Seq instance.
+        /// </summary>
         InstanceTitle,
+
+        /// <summary>
+        /// If <c>true</c>, the server supports Active Directory authentication.
+        /// </summary>
         IsActiveDirectoryAuthentication,
+
+        /// <summary>
+        /// If <c>true</c>, the server has authentication enabled.
+        /// </summary>
         IsAuthenticationEnabled,
+
+        /// <summary>
+        /// Obsolete.
+        /// </summary>
         LazilyFlushEventWrites,
+
+        /// <summary>
+        /// Tracks whether an admin user has dismissed the master key backup warning.
+        /// </summary>
         MasterKeyIsBackedUp,
+
+        /// <summary>
+        /// The minimum storage space, in bytes, on the disk containing log events, before
+        /// Seq will stop accepting new events.
+        /// </summary>
         MinimumFreeStorageSpace,
+
+        /// <summary>
+        /// A comma-separated list of (shared) signal ids that will be included in any new user's
+        /// personal default workspace.
+        /// </summary>
         NewUserShowSignalIds,
+
+        /// <summary>
+        /// A comma-separated list of (shared) SQL query ids that will be included in any new user's
+        /// personal default workspace.
+        /// </summary>
         NewUserShowQueryIds,
+
+        /// <summary>
+        /// A comma-separated list of (shared) dashboard ids that will be included in any new user's
+        /// personal default workspace.
+        /// </summary>
         NewUserShowDashboardIds,
+
+        /// <summary>
+        /// If <c>true</c>, ingestion requests incoming via HTTP must be authenticated using an API key or
+        /// logged-in user session. Only effective when <see cref="IsAuthenticationEnabled"/> is <c>true</c>.
+        /// </summary>
         RequireApiKeyForWritingEvents,
+
+        /// <summary>
+        /// The maximum size, in bytes of UTF-8-encoded JSON, beyond which individual events will be rejected.
+        /// </summary>
         RawEventMaximumContentLength,
+
+        /// <summary>
+        /// The maximum size, in HTTP request content bytes, beyond which ingestion requests will be rejected.
+        /// </summary>
         RawPayloadMaximumContentLength,
+
+        /// <summary>
+        /// A snippet of CSS that will be included in the front-end's user interface styles.
+        /// </summary>
         ThemeStyles
     }
 }

--- a/src/Seq.Api/Model/Shared/DeferredRequestEntity.cs
+++ b/src/Seq.Api/Model/Shared/DeferredRequestEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Shared/DeferredRequestEntity.cs
+++ b/src/Seq.Api/Model/Shared/DeferredRequestEntity.cs
@@ -1,5 +1,23 @@
-﻿namespace Seq.Api.Model.Shared
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Seq.Api.Model.Shared
 {
+    /// <summary>
+    /// An entity representing a request that will be executed as a long-running (background) task.
+    /// Includes a link where the result of the request can be accessed.
+    /// </summary>
     public class DeferredRequestEntity : Entity
     {
     }

--- a/src/Seq.Api/Model/Shared/DescriptiveFilterPart.cs
+++ b/src/Seq.Api/Model/Shared/DescriptiveFilterPart.cs
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace Seq.Api.Model.Signals
+namespace Seq.Api.Model.Shared
 {
     /// <summary>
-    /// An individual filter incorporated within a signal.
+    /// An expression-based filter that carries additional descriptive information.
     /// </summary>
-    public class SignalFilterPart
+    public class DescriptiveFilterPart
     {
         /// <summary>
         /// A friendly, human-readable description of the filter.

--- a/src/Seq.Api/Model/Shared/ErrorPart.cs
+++ b/src/Seq.Api/Model/Shared/ErrorPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Shared/ErrorPart.cs
+++ b/src/Seq.Api/Model/Shared/ErrorPart.cs
@@ -1,7 +1,27 @@
-﻿namespace Seq.Api.Model.Shared
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Seq.Api.Model.Shared
 {
+    /// <summary>
+    /// An error returned from the API.
+    /// </summary>
     public class ErrorPart
     {
+        /// <summary>
+        /// The error message.
+        /// </summary>
         public string Error { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Shared/ResultSetStatus.cs
+++ b/src/Seq.Api/Model/Shared/ResultSetStatus.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Shared/ResultSetStatus.cs
+++ b/src/Seq.Api/Model/Shared/ResultSetStatus.cs
@@ -1,16 +1,42 @@
-﻿namespace Seq.Api.Model.Shared
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Seq.Api.Model.Shared
 {
+    /// <summary>
+    /// Information about the state of an event result set.
+    /// </summary>
     public enum ResultSetStatus
     {
+        /// <summary>
+        /// Uninitialized value.
+        /// </summary>
         Unknown,
 
-        // Still more to come, scanned as far as requested/short circuit
+        /// <summary>
+        /// Still more to search (even if this result set is empty).
+        /// </summary>
         Partial,
 
-        // Have covered the whole range
+        /// <summary>
+        /// Covers the whole range.
+        /// </summary>
         Complete,
 
-        // You asked for 10, I got you 10
+        /// <summary>
+        /// Retrieved the requested event count, then stopped.
+        /// </summary>
         Full
     }
 }

--- a/src/Seq.Api/Model/Shared/StatisticsPart.cs
+++ b/src/Seq.Api/Model/Shared/StatisticsPart.cs
@@ -1,14 +1,55 @@
-﻿using System;
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 
 namespace Seq.Api.Model.Shared
 {
+    /// <summary>
+    /// Information about a request to search for events.
+    /// </summary>
     public class StatisticsPart
     {
+        /// <summary>
+        /// The server-side elapsed time taken satisfying the request.
+        /// </summary>
         public TimeSpan Elapsed { get; set; }
+
+        /// <summary>
+        /// The number of events that were scanned in the search (and were not
+        /// able to be excluded based on index information or pre-filtering).
+        /// </summary>
         public long ScannedEventCount { get; set; }
+
+        /// <summary>
+        /// The id of the last event inspected in the search.
+        /// </summary>
         public string LastReadEventId { get; set; }
+
+        /// <summary>
+        /// The timestamp of the last event inspected in the search.
+        /// </summary>
         public string LastReadEventTimestamp { get; set; }
+
+        /// <summary>
+        /// Status of the result set.
+        /// </summary>
         public ResultSetStatus Status { get; set; }
+
+        /// <summary>
+        /// Whether it was necessary to read from disk in processing this request.
+        /// </summary>
         public bool UncachedSegmentsScanned { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Shared/StatisticsPart.cs
+++ b/src/Seq.Api/Model/Shared/StatisticsPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ namespace Seq.Api.Model.Shared
         /// The number of events that were scanned in the search (and were not
         /// able to be excluded based on index information or pre-filtering).
         /// </summary>
-        public long ScannedEventCount { get; set; }
+        public ulong ScannedEventCount { get; set; }
 
         /// <summary>
         /// The id of the last event inspected in the search.

--- a/src/Seq.Api/Model/Signals/SignalColumnPart.cs
+++ b/src/Seq.Api/Model/Signals/SignalColumnPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,14 +15,14 @@
 namespace Seq.Api.Model.Signals
 {
     /// <summary>
-    /// A property that will be displayed as a column when a signal
+    /// An expression that will be displayed as a column when a signal
     /// including it is selected.
     /// </summary>
-    public class TaggedPropertyPart
+    public class SignalColumnPart
     {
         /// <summary>
-        /// The property name.
+        /// The expression to show as a column.
         /// </summary>
-        public string PropertyName { get; set; }
+        public string Expression { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Signals/SignalEntity.cs
+++ b/src/Seq.Api/Model/Signals/SignalEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ namespace Seq.Api.Model.Signals
         {
             Title = "New Signal";
             Filters = new List<SignalFilterPart>();
-            TaggedProperties = new List<TaggedPropertyPart>();
+            Columns = new List<SignalColumnPart>();
         }
 
         /// <summary>
@@ -50,9 +50,9 @@ namespace Seq.Api.Model.Signals
         public List<SignalFilterPart> Filters { get; set; }
 
         /// <summary>
-        /// Properties that show as columns when the signal is selected in the events screen.
+        /// Expressions that show as columns when the signal is selected in the events screen.
         /// </summary>
-        public List<TaggedPropertyPart> TaggedProperties { get; set; }
+        public List<SignalColumnPart> Columns { get; set; }
 
         /// <summary>
         /// Obsolete.

--- a/src/Seq.Api/Model/Signals/SignalEntity.cs
+++ b/src/Seq.Api/Model/Signals/SignalEntity.cs
@@ -1,11 +1,32 @@
-﻿using System;
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using Seq.Api.Model.Security;
 
 namespace Seq.Api.Model.Signals
 {
+    /// <summary>
+    /// A signal is a collection of filters that identifies a subset of the event stream.
+    /// </summary>
     public class SignalEntity : Entity
     {
+        /// <summary>
+        /// Construct a <see cref="SignalEntity"/>.
+        /// </summary>
         public SignalEntity()
         {
             Title = "New Signal";
@@ -13,25 +34,52 @@ namespace Seq.Api.Model.Signals
             TaggedProperties = new List<TaggedPropertyPart>();
         }
 
+        /// <summary>
+        /// The friendly, human readable title of the signal.
+        /// </summary>
         public string Title { get; set; }
 
+        /// <summary>
+        /// A long-form description of the signal's purpose and contents.
+        /// </summary>
         public string Description { get; set; }
 
+        /// <summary>
+        /// Filters that are combined (using the <c>and</c> operator) to identify events matching the filter.
+        /// </summary>
         public List<SignalFilterPart> Filters { get; set; }
 
+        /// <summary>
+        /// Properties that show as columns when the signal is selected in the events screen.
+        /// </summary>
         public List<TaggedPropertyPart> TaggedProperties { get; set; }
 
+        /// <summary>
+        /// Obsolete.
+        /// </summary>
         // ReSharper disable once UnusedMember.Global
         [Obsolete("This member has been renamed `IsProtected` to better reflect its purpose.")]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public bool? IsRestricted { get; set; }
 
+        /// <summary>
+        /// If <c>true</c>, the signal can only be modified by users with the <see cref="Permission.Setup"/> permission.
+        /// </summary>
         public bool IsProtected { get; set; }
 
+        /// <summary>
+        /// How the signal is grouped in the Seq UI.
+        /// </summary>
         public SignalGrouping Grouping { get; set; }
 
+        /// <summary>
+        /// If <see cref="Grouping"/> is <see cref="SignalGrouping.Explicit"/>, the name of the group in which the signal appears.
+        /// </summary>
         public string ExplicitGroupName { get; set; }
 
+        /// <summary>
+        /// The user id of the user who owns the signal; if <c>null</c>, the signal is shared.
+        /// </summary>
         public string OwnerId { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Signals/SignalEntity.cs
+++ b/src/Seq.Api/Model/Signals/SignalEntity.cs
@@ -16,6 +16,7 @@ using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using Seq.Api.Model.Security;
+using Seq.Api.Model.Shared;
 
 namespace Seq.Api.Model.Signals
 {
@@ -30,7 +31,7 @@ namespace Seq.Api.Model.Signals
         public SignalEntity()
         {
             Title = "New Signal";
-            Filters = new List<SignalFilterPart>();
+            Filters = new List<DescriptiveFilterPart>();
             Columns = new List<SignalColumnPart>();
         }
 
@@ -47,7 +48,7 @@ namespace Seq.Api.Model.Signals
         /// <summary>
         /// Filters that are combined (using the <c>and</c> operator) to identify events matching the filter.
         /// </summary>
-        public List<SignalFilterPart> Filters { get; set; }
+        public List<DescriptiveFilterPart> Filters { get; set; }
 
         /// <summary>
         /// Expressions that show as columns when the signal is selected in the events screen.

--- a/src/Seq.Api/Model/Signals/SignalExpressionKind.cs
+++ b/src/Seq.Api/Model/Signals/SignalExpressionKind.cs
@@ -1,10 +1,42 @@
-﻿namespace Seq.Api.Model.Signals
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Seq.Api.Model.Signals
 {
+    /// <summary>
+    /// The type of expression represented by a <see cref="SignalExpressionPart"/>.
+    /// </summary>
     public enum SignalExpressionKind
     {
+        /// <summary>
+        /// Uninitialized value.
+        /// </summary>
         None,
+
+        /// <summary>
+        /// The expression identifies a single signal.
+        /// </summary>
         Signal,
+
+        /// <summary>
+        /// The expression is an intersection (<c>and</c> operation) of two signal expressions.
+        /// </summary>
         Intersection,
+
+        /// <summary>
+        /// The expression is a union (<c>or</c> operation) of two signal expressions.
+        /// </summary>
         Union
     }
 }

--- a/src/Seq.Api/Model/Signals/SignalExpressionKind.cs
+++ b/src/Seq.Api/Model/Signals/SignalExpressionKind.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Signals/SignalExpressionPart.cs
+++ b/src/Seq.Api/Model/Signals/SignalExpressionPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Signals/SignalExpressionPart.cs
+++ b/src/Seq.Api/Model/Signals/SignalExpressionPart.cs
@@ -1,33 +1,75 @@
-﻿using System;
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
 
 namespace Seq.Api.Model.Signals
 {
+    /// <summary>
+    /// A signal expression combines one or more signals to identify a subset of events.
+    /// </summary>
     public class SignalExpressionPart
     {
+        /// <summary>
+        /// The kind of this expression. Signal expressions form a tree of nodes; the <see cref="Kind"/>
+        /// determines what kind of node this expression is, and therefore which other properties
+        /// of the <see cref="SignalExpressionPart"/> are valid.
+        /// </summary>
         public SignalExpressionKind Kind { get; set; }
 
-        // SignalExpressionKind.Signal
-
+        /// <summary>
+        /// When <see cref="Kind"/> is <see cref="SignalExpressionKind.Signal"/>, the id of the
+        /// signal represented by this expression node.
+        /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string SignalId { get; set; }
 
-        // SignalExpressionKind.Intersection, SignalExpressionKind.Union
-
+        /// <summary>
+        /// When <see cref="Kind"/> is <see cref="SignalExpressionKind.Intersection"/> or
+        /// <see cref="SignalExpressionKind.Union"/>, the left side of the operation.
+        /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public SignalExpressionPart Left { get; set; }
 
+        /// <summary>
+        /// When <see cref="Kind"/> is <see cref="SignalExpressionKind.Intersection"/> or
+        /// <see cref="SignalExpressionKind.Union"/>, the right side of the operation.
+        /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public SignalExpressionPart Right { get; set; }
 
+        /// <summary>
+        /// Create a <see cref="SignalExpressionPart"/> representing a single signal.
+        /// </summary>
+        /// <param name="signalId">The id of the signal.</param>
+        /// <returns>The equivalent expression.</returns>
         public static SignalExpressionPart Signal(string signalId)
         {
             if (signalId == null) throw new ArgumentNullException(nameof(signalId));
             return new SignalExpressionPart {Kind = SignalExpressionKind.Signal, SignalId = signalId};
         }
 
+        /// <summary>
+        /// Create a <see cref="SignalExpressionPart"/> representing an intersection (<c>and</c> operation)
+        /// of two signal expressions.
+        /// </summary>
+        /// <param name="left">The left side of the operation.</param>
+        /// <param name="right">The right side of the operation.</param>
+        /// <returns>The equivalent expression.</returns>
         public static SignalExpressionPart Intersection(SignalExpressionPart left, SignalExpressionPart right)
         {
             if (left == null) throw new ArgumentNullException(nameof(left));
@@ -41,6 +83,13 @@ namespace Seq.Api.Model.Signals
             };
         }
 
+        /// <summary>
+        /// Create a <see cref="SignalExpressionPart"/> representing an union (<c>or</c> operation)
+        /// of two signal expressions.
+        /// </summary>
+        /// <param name="left">The left side of the operation.</param>
+        /// <param name="right">The right side of the operation.</param>
+        /// <returns>The equivalent expression.</returns>
         public static SignalExpressionPart Union(SignalExpressionPart left, SignalExpressionPart right)
         {
             if (left == null) throw new ArgumentNullException(nameof(left));
@@ -54,6 +103,12 @@ namespace Seq.Api.Model.Signals
             };
         }
 
+        /// <summary>
+        /// Create a <see cref="SignalExpressionPart"/> representing an intersection (<c>and</c> operation)
+        /// of multiple signals.
+        /// </summary>
+        /// <param name="intersectIds">The ids of the intersected signals.</param>
+        /// <returns>The equivalent expression.</returns>
         public static SignalExpressionPart FromIntersectedIds(IEnumerable<string> intersectIds)
         {
             if (intersectIds == null) throw new ArgumentNullException(nameof(intersectIds));
@@ -65,6 +120,7 @@ namespace Seq.Api.Model.Signals
             return intersectIds.Skip(1).Aggregate(first, (lhs, rhs) => Intersection(lhs, Signal(rhs)));
         }
 
+        /// <inheritdoc/>
         public override string ToString()
         {
             if (Kind == SignalExpressionKind.Signal)

--- a/src/Seq.Api/Model/Signals/SignalFilterPart.cs
+++ b/src/Seq.Api/Model/Signals/SignalFilterPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Signals/SignalFilterPart.cs
+++ b/src/Seq.Api/Model/Signals/SignalFilterPart.cs
@@ -1,10 +1,46 @@
-﻿namespace Seq.Api.Model.Signals
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Seq.Api.Model.Signals
 {
+    /// <summary>
+    /// An individual filter incorporated within a signal.
+    /// </summary>
     public class SignalFilterPart
     {
+        /// <summary>
+        /// A friendly, human-readable description of the filter.
+        /// </summary>
         public string Description { get; set; }
+
+        /// <summary>
+        /// If <c>true</c>, the description identifies events excluded by the filter. The
+        /// Seq UI uses this to show the description in strikethrough.
+        /// </summary>
         public bool DescriptionIsExcluded { get; set; }
+
+        /// <summary>
+        /// The strictly-valid expression language filter that identifies matching events.
+        /// </summary>
         public string Filter { get; set; }
+
+        /// <summary>
+        /// The original ("fuzzy") text entered by the user into the filter bar when
+        /// creating the filter. This may not be syntactically valid, e.g. it may be
+        /// interpreted as free text - hence while it's displayed in the UI and forms the
+        /// basis of user editing of the filter, the <see cref="Filter"/> value is executed.
+        /// </summary>
         public string FilterNonStrict { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Signals/SignalGrouping.cs
+++ b/src/Seq.Api/Model/Signals/SignalGrouping.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Signals/SignalGrouping.cs
+++ b/src/Seq.Api/Model/Signals/SignalGrouping.cs
@@ -1,9 +1,39 @@
-﻿namespace Seq.Api.Model.Signals
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Seq.Api.Model.Signals
 {
+    /// <summary>
+    /// The method by which a signal is grouped in the Seq UI.
+    /// </summary>
     public enum SignalGrouping
     {
+        /// <summary>
+        /// The grouping is inferred from the filters within the signal. Currently, this
+        /// will result in the signal being grouped only if the signal has a single
+        /// equality-based filter.
+        /// </summary>
         Inferred,
+
+        /// <summary>
+        /// The signal is given an explicit group name.
+        /// </summary>
         Explicit,
+
+        /// <summary>
+        /// The signal is never displayed in a group.
+        /// </summary>
         None
     }
 }

--- a/src/Seq.Api/Model/Signals/TaggedPropertyPart.cs
+++ b/src/Seq.Api/Model/Signals/TaggedPropertyPart.cs
@@ -1,7 +1,28 @@
-﻿namespace Seq.Api.Model.Signals
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Seq.Api.Model.Signals
 {
+    /// <summary>
+    /// A property that will be displayed as a column when a signal
+    /// including it is selected.
+    /// </summary>
     public class TaggedPropertyPart
     {
+        /// <summary>
+        /// The property name.
+        /// </summary>
         public string PropertyName { get; set; }
     }
 }

--- a/src/Seq.Api/Model/SqlQueries/SqlQueryEntity.cs
+++ b/src/Seq.Api/Model/SqlQueries/SqlQueryEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/SqlQueries/SqlQueryEntity.cs
+++ b/src/Seq.Api/Model/SqlQueries/SqlQueryEntity.cs
@@ -1,21 +1,58 @@
-﻿namespace Seq.Api.Model.SqlQueries
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Seq.Api.Model.Security;
+
+namespace Seq.Api.Model.SqlQueries
 {
+    /// <summary>
+    /// A saved SQL-style query.
+    /// </summary>
     public class SqlQueryEntity : Entity
     {
+        /// <summary>
+        /// Construct a <see cref="SqlQueryEntity"/>.
+        /// </summary>
         public SqlQueryEntity()
         {
             Title = "New SQL Query";
             Sql = "";
         }
 
+        /// <summary>
+        /// A friendly, human-readable name for the query.
+        /// </summary>
         public string Title { get; set; }
 
+        /// <summary>
+        /// A long-form description of the query.
+        /// </summary>
         public string Description { get; set; }
 
+        /// <summary>
+        /// The query text.
+        /// </summary>
         public string Sql { get; set; }
 
+        /// <summary>
+        /// If <c>true</c>, only users with <see cref="Permission.Setup"/> permission can edit the signal.
+        /// </summary>
         public bool IsProtected { get; set; }
 
+        /// <summary>
+        /// The id of a user who owns this query. If <c>null</c>, the query is shared.
+        /// </summary>
         public string OwnerId { get; set; }
 
     }

--- a/src/Seq.Api/Model/Tasks/RunningTaskEntity.cs
+++ b/src/Seq.Api/Model/Tasks/RunningTaskEntity.cs
@@ -14,18 +14,13 @@
 
 using System;
 
-namespace Seq.Api.Model.Diagnostics
+namespace Seq.Api.Model.Tasks
 {
     /// <summary>
     /// Describes a task being actively performed by the Seq server.
     /// </summary>
-    public class RunningTaskPart
+    public class RunningTaskEntity: Entity
     {
-        /// <summary>
-        /// A unique identifier for the task.
-        /// </summary>
-        public Guid Id { get; set; }
-
         /// <summary>
         /// A description of the task.
         /// </summary>
@@ -35,5 +30,10 @@ namespace Seq.Api.Model.Diagnostics
         /// When the task started.
         /// </summary>
         public DateTime StartedAtUtc { get; set; }
+
+        /// <summary>
+        /// Whether or not the task can be cancelled.
+        /// </summary>
+        public bool CanCancel { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Updates/AvailableUpdateEntity.cs
+++ b/src/Seq.Api/Model/Updates/AvailableUpdateEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Updates/AvailableUpdateEntity.cs
+++ b/src/Seq.Api/Model/Updates/AvailableUpdateEntity.cs
@@ -1,7 +1,27 @@
-﻿namespace Seq.Api.Model.Updates
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Seq.Api.Model.Updates
 {
+    /// <summary>
+    /// An update available for software running on or in the Seq server.
+    /// </summary>
     public class AvailableUpdateEntity : Entity
     {
+        /// <summary>
+        /// A description of the update.
+        /// </summary>
         public string Description { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Users/AuthProviderInfoPart.cs
+++ b/src/Seq.Api/Model/Users/AuthProviderInfoPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Users/AuthProviderInfoPart.cs
+++ b/src/Seq.Api/Model/Users/AuthProviderInfoPart.cs
@@ -1,9 +1,38 @@
-﻿namespace Seq.Api.Model.Users
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Seq.Api.Model.Users
 {
+    /// <summary>
+    /// An authentication provider supported by the server.
+    /// </summary>
     public class AuthProviderInfoPart
     {
+        /// <summary>
+        /// The friendly, human-readable name of the authentication provider.
+        /// </summary>
         public string Name { get; set; }
+
+        /// <summary>
+        /// The URL where the user can log in with the provider.
+        /// </summary>
         public string Url { get; set; }
+
+        /// <summary>
+        /// If <c>true</c>, the provider is shown as an additional/alternative way to
+        /// log in using the default provider.
+        /// </summary>
         public bool IsAlternative { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Users/AuthProvidersPart.cs
+++ b/src/Seq.Api/Model/Users/AuthProvidersPart.cs
@@ -1,9 +1,29 @@
-﻿using System.Collections.Generic;
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
 
 namespace Seq.Api.Model.Users
 {
+    /// <summary>
+    /// Auth providers supported by the server.
+    /// </summary>
     public class AuthProvidersPart
     {
+        /// <summary>
+        /// The providers.
+        /// </summary>
         public List<AuthProviderInfoPart> Providers { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Users/AuthProvidersPart.cs
+++ b/src/Seq.Api/Model/Users/AuthProvidersPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Users/CredentialsPart.cs
+++ b/src/Seq.Api/Model/Users/CredentialsPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Users/CredentialsPart.cs
+++ b/src/Seq.Api/Model/Users/CredentialsPart.cs
@@ -1,9 +1,37 @@
-﻿namespace Seq.Api.Model.Users
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Seq.Api.Model.Users
 {
+    /// <summary>
+    /// User credentials.
+    /// </summary>
     public class CredentialsPart
     {
+        /// <summary>
+        /// The username.
+        /// </summary>
         public string Username { get; set; }
+
+        /// <summary>
+        /// The current password; set e.g. when logging in.
+        /// </summary>
         public string Password { get; set; }
+
+        /// <summary>
+        /// A new password; set e.g. when changing passwords.
+        /// </summary>
         public string NewPassword { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Users/SearchHistoryEntity.cs
+++ b/src/Seq.Api/Model/Users/SearchHistoryEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Users/SearchHistoryEntity.cs
+++ b/src/Seq.Api/Model/Users/SearchHistoryEntity.cs
@@ -1,11 +1,39 @@
-﻿using System.Collections.Generic;
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
 
 namespace Seq.Api.Model.Users
 {
+    /// <summary>
+    /// A user's search history.
+    /// </summary>
     public class SearchHistoryEntity : Entity
     {
+        /// <summary>
+        /// The number of recent searches that the server will retain for the user.
+        /// </summary>
         public uint RetainedRecentSearches { get; set; }
+
+        /// <summary>
+        /// Recent un-pinned searches, with the most recent included first.
+        /// </summary>
         public List<string> Recent { get; set; }
+
+        /// <summary>
+        /// Pinned search history items, with the most recent included first.
+        /// </summary>
         public List<string> Pinned { get; set; } 
     }
 }

--- a/src/Seq.Api/Model/Users/SearchHistoryItemPart.cs
+++ b/src/Seq.Api/Model/Users/SearchHistoryItemPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Users/SearchHistoryItemPart.cs
+++ b/src/Seq.Api/Model/Users/SearchHistoryItemPart.cs
@@ -1,8 +1,32 @@
-﻿namespace Seq.Api.Model.Users
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Seq.Api.Model.Users
 {
+    /// <summary>
+    /// A entry to include in a user's search history.
+    /// </summary>
     public class SearchHistoryItemPart
     {
+        /// <summary>
+        /// The filter entered by the user into the filter bar.
+        /// </summary>
         public string Search { get; set; }
+
+        /// <summary>
+        /// Status to apply to the search history item.
+        /// </summary>
         public SearchHistoryItemStatus Status { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Users/SearchHistoryItemStatus.cs
+++ b/src/Seq.Api/Model/Users/SearchHistoryItemStatus.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Users/SearchHistoryItemStatus.cs
+++ b/src/Seq.Api/Model/Users/SearchHistoryItemStatus.cs
@@ -1,9 +1,37 @@
-﻿namespace Seq.Api.Model.Users
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Seq.Api.Model.Users
 {
+    /// <summary>
+    /// An operation applied to a search history item.
+    /// </summary>
     public enum SearchHistoryItemStatus
     {
+        /// <summary>
+        /// The item was used (make it more recent).
+        /// </summary>
         Used,
+
+        /// <summary>
+        /// The item has been pinned.
+        /// </summary>
         Pinned,
+
+        /// <summary>
+        /// The item has been un-pinned.
+        /// </summary>
         Forgotten
     }
 }

--- a/src/Seq.Api/Model/Users/UserEntity.cs
+++ b/src/Seq.Api/Model/Users/UserEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Users/UserEntity.cs
+++ b/src/Seq.Api/Model/Users/UserEntity.cs
@@ -1,17 +1,70 @@
-﻿using System.Collections.Generic;
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
 using Seq.Api.Model.Signals;
 
 namespace Seq.Api.Model.Users
 {
+    /// <summary>
+    /// A user on the Seq server.
+    /// </summary>
     public class UserEntity : Entity
     {
+        /// <summary>
+        /// The username that uniquely identifies the user.
+        /// </summary>
         public string Username { get; set; }
+
+        /// <summary>
+        /// An optional display name to aid in identifying the user.
+        /// </summary>
         public string DisplayName { get; set; }
+
+        /// <summary>
+        /// The user's email address. This will be used to show a
+        /// Gravatar for the user in some situations.
+        /// </summary>
         public string EmailAddress { get; set; }
+        
+        /// <summary>
+        /// The user's preferences.
+        /// </summary>
         public Dictionary<string, object> Preferences { get; set; }
+
+        /// <summary>
+        /// If changing password, the new password for the user.
+        /// </summary>
         public string NewPassword { get; set; }
+
+        /// <summary>
+        /// A filter that is applied to searches and queries instigated by
+        /// the user.
+        /// </summary>
         public SignalFilterPart ViewFilter { get; set; }
+
+        /// <summary>
+        /// If <c>true</c>, the user will be unable to log in without first
+        /// changing their password. Recommended when administratively assigning
+        /// a password for the user.
+        /// </summary>
         public bool MustChangePassword { get; set; }
+
+        /// <summary>
+        /// The ids of one or more roles that grant permissions to the user. Note that
+        /// the Seq UI currently only supports a single role when editing users.
+        /// </summary>
         public HashSet<string> RoleIds { get; set; } = new HashSet<string>();
     }
 }

--- a/src/Seq.Api/Model/Users/UserEntity.cs
+++ b/src/Seq.Api/Model/Users/UserEntity.cs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 using System.Collections.Generic;
+using Newtonsoft.Json;
+using Seq.Api.Model.Shared;
 using Seq.Api.Model.Signals;
 
 namespace Seq.Api.Model.Users
@@ -46,19 +48,22 @@ namespace Seq.Api.Model.Users
         /// <summary>
         /// If changing password, the new password for the user.
         /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string NewPassword { get; set; }
 
         /// <summary>
         /// A filter that is applied to searches and queries instigated by
         /// the user.
         /// </summary>
-        public SignalFilterPart ViewFilter { get; set; }
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public DescriptiveFilterPart ViewFilter { get; set; }
 
         /// <summary>
         /// If <c>true</c>, the user will be unable to log in without first
         /// changing their password. Recommended when administratively assigning
         /// a password for the user.
         /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public bool MustChangePassword { get; set; }
 
         /// <summary>
@@ -66,5 +71,21 @@ namespace Seq.Api.Model.Users
         /// the Seq UI currently only supports a single role when editing users.
         /// </summary>
         public HashSet<string> RoleIds { get; set; } = new HashSet<string>();
+
+        /// <summary>
+        /// The authentication provider associated with the user account. This will normally be
+        /// the system-configured authentication provider, but if the provider is changed, the
+        /// user may need to be unlinked from an existing provider so that login can proceed through
+        /// the new provider.
+        /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string AuthenticationProvider { get; set; }
+
+        /// <summary>
+        /// The unique identifier that links the identity provided by the authentication provider
+        /// with the Seq user.
+        /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string AuthenticationProviderUniqueIdentifier { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Workspaces/WorkspaceContentPart.cs
+++ b/src/Seq.Api/Model/Workspaces/WorkspaceContentPart.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Workspaces/WorkspaceContentPart.cs
+++ b/src/Seq.Api/Model/Workspaces/WorkspaceContentPart.cs
@@ -1,11 +1,42 @@
-﻿using System.Collections.Generic;
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using Seq.Api.Model.Monitoring;
+using Seq.Api.Model.Signals;
+using Seq.Api.Model.SqlQueries;
 
 namespace Seq.Api.Model.Workspaces
 {
+    /// <summary>
+    /// The items included in a <see cref="WorkspaceEntity"/>.
+    /// </summary>
     public class WorkspaceContentPart
     {
+        /// <summary>
+        /// A list of <see cref="SignalEntity"/> ids to include in the workspace.
+        /// </summary>
         public List<string> SignalIds { get; set; } = new List<string>();
+
+        /// <summary>
+        /// A list of <see cref="SqlQueryEntity"/> ids to include in the workspace.
+        /// </summary>
         public List<string> QueryIds { get; set; } = new List<string>();
+        
+        /// <summary>
+        /// A list of <see cref="DashboardEntity"/> ids to include in the workspace.
+        /// </summary>
         public List<string> DashboardIds { get; set; } = new List<string>();
     }
 }

--- a/src/Seq.Api/Model/Workspaces/WorkspaceEntity.cs
+++ b/src/Seq.Api/Model/Workspaces/WorkspaceEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Model/Workspaces/WorkspaceEntity.cs
+++ b/src/Seq.Api/Model/Workspaces/WorkspaceEntity.cs
@@ -1,12 +1,50 @@
-﻿namespace Seq.Api.Model.Workspaces
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Seq.Api.Model.Security;
+
+namespace Seq.Api.Model.Workspaces
 {
+    /// <summary>
+    /// A workspace is a collection of related entities that help to focus
+    /// the Seq UI around a particular context.
+    /// </summary>
     public class WorkspaceEntity : Entity
     {
+        /// <summary>
+        /// A friendly, human-readable title for the workspace.
+        /// </summary>
         public string Title { get; set; }
+
+        /// <summary>
+        /// A long-form description of the workspace.
+        /// </summary>
         public string Description { get; set; }
+
+        /// <summary>
+        /// The id of the user who owns the workspace. If <c>null</c>, the workspace is shared.
+        /// </summary>
         public string OwnerId { get; set; }
+
+        /// <summary>
+        /// If <c>true</c>, only users with the <see cref="Permission.Setup"/> permission can modify the workspace.
+        /// </summary>
         public bool IsProtected { get; set; }
 
+        /// <summary>
+        /// Content included in the workspace.
+        /// </summary>
         public WorkspaceContentPart Content { get; set; } = new WorkspaceContentPart();
     }
 }

--- a/src/Seq.Api/ResourceGroups/AlertStateResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/AlertStateResourceGroup.cs
@@ -1,0 +1,65 @@
+﻿// Copyright Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Seq.Api.Model.Monitoring;
+
+namespace Seq.Api.ResourceGroups
+{
+    /// <summary>
+    /// Inspect the current states of alerts being monitored by the server..
+    /// </summary>
+    public class AlertStateResourceGroup : ApiResourceGroup
+    {
+        internal AlertStateResourceGroup(ISeqConnection connection)
+            : base("AlertState", connection)
+        {
+        }
+
+        /// <summary>
+        /// Retrieve the alert state with the given id; throws if the entity does not exist.
+        /// </summary>
+        /// <param name="id">The id of the alert state.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The alert state.</returns>
+        public async Task<AlertStateEntity> FindAsync(string id, CancellationToken cancellationToken = default)
+        {
+            if (id == null) throw new ArgumentNullException(nameof(id));
+            return await GroupGetAsync<AlertStateEntity>("Item", new Dictionary<string, object> { { "id", id } }, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Retrieve the states of all alerts being monitored by the server.
+        /// </summary>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>A list containing all current alert states.</returns>
+        public async Task<List<AlertStateEntity>> ListAsync(CancellationToken cancellationToken = default)
+        {
+            return await GroupListAsync<AlertStateEntity>("Items", null, cancellationToken).ConfigureAwait(false);
+        }
+    
+        /// <summary>
+        /// Remove an alert state; this will remove the corresponding alert.
+        /// </summary>
+        /// <param name="entity">The alert state to remove</param>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        public async Task RemoveAsync(AlertStateEntity entity, CancellationToken cancellationToken = default)
+        {
+            await Client.DeleteAsync(entity, "Self", entity, cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Seq.Api/ResourceGroups/AlertStateResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/AlertStateResourceGroup.cs
@@ -21,7 +21,7 @@ using Seq.Api.Model.Monitoring;
 namespace Seq.Api.ResourceGroups
 {
     /// <summary>
-    /// Inspect the current states of alerts being monitored by the server..
+    /// Inspect the current states of alerts being monitored by the server.
     /// </summary>
     public class AlertStateResourceGroup : ApiResourceGroup
     {

--- a/src/Seq.Api/ResourceGroups/ApiKeysResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/ApiKeysResourceGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/ResourceGroups/ApiKeysResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/ApiKeysResourceGroup.cs
@@ -17,6 +17,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Seq.Api.Model;
+using Seq.Api.Model.Diagnostics;
 using Seq.Api.Model.Inputs;
 using Seq.Api.Model.Users;
 
@@ -106,6 +107,19 @@ namespace Seq.Api.ResourceGroups
         public async Task UpdateAsync(ApiKeyEntity entity, CancellationToken cancellationToken = default)
         {
             await Client.PutAsync(entity, "Self", entity, cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Retrieve a detailed metric for the API key.
+        /// </summary>
+        /// <param name="entity">The API key to retrieve metrics for.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <param name="measurement">The measurement to get.</param>
+        /// <returns></returns>
+        public async Task<MeasurementTimeseriesPart> GetMeasurementTimeseriesAsync(ApiKeyEntity entity, string measurement, CancellationToken cancellationToken = default)
+        {
+            var parameters = new Dictionary<string, object>{ ["id"] = entity.Id, ["measurement"] = measurement };
+            return await GroupGetAsync<MeasurementTimeseriesPart>("Metric", parameters, cancellationToken);
         }
     }
 }

--- a/src/Seq.Api/ResourceGroups/ApiKeysResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/ApiKeysResourceGroup.cs
@@ -1,11 +1,32 @@
-﻿using System;
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Seq.Api.Model;
 using Seq.Api.Model.Inputs;
+using Seq.Api.Model.Users;
 
 namespace Seq.Api.ResourceGroups
 {
+    /// <summary>
+    /// Perform actions on API keys. API keys can be used to authenticate and identify log event sources, and for
+    /// users to delegate some or all permissions to a client of the Seq API (app or integration) without exposing
+    /// user credentials.
+    /// </summary>
     public class ApiKeysResourceGroup : ApiResourceGroup
     {
         internal ApiKeysResourceGroup(ISeqConnection connection)
@@ -13,33 +34,75 @@ namespace Seq.Api.ResourceGroups
         {
         }
 
+        /// <summary>
+        /// Retrieve the API key with the given id; throws if the entity does not exist.
+        /// </summary>
+        /// <param name="id">The id of the API key.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The API key.</returns>
         public async Task<ApiKeyEntity> FindAsync(string id, CancellationToken cancellationToken = default)
         {
             if (id == null) throw new ArgumentNullException(nameof(id));
             return await GroupGetAsync<ApiKeyEntity>("Item", new Dictionary<string, object> { { "id", id } }, cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<List<ApiKeyEntity>> ListAsync(string ownerId = null, CancellationToken cancellationToken = default)
+        /// <summary>
+        /// Retrieve API keys.
+        /// </summary>
+        /// <param name="ownerId">If the id of a <see cref="UserEntity"/> is provided, only API keys owned by them will be included in the result; if
+        /// not specified, personal API keys for all owners will be listed.</param>
+        /// <param name="shared">If <c>true</c>, shared API keys will be included in the result.</param>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>A list containing matching API keys.</returns>
+        public async Task<List<ApiKeyEntity>> ListAsync(string ownerId = null, bool shared = false, CancellationToken cancellationToken = default)
         {
-            var parameters = new Dictionary<string, object> { { "ownerId", ownerId } };
+            var parameters = new Dictionary<string, object> { { "ownerId", ownerId }, {"shared", shared} };
             return await GroupListAsync<ApiKeyEntity>("Items", parameters, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Construct an API key with server defaults pre-initialized.
+        /// </summary>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The unsaved API key.</returns>
         public async Task<ApiKeyEntity> TemplateAsync(CancellationToken cancellationToken = default)
         {
             return await GroupGetAsync<ApiKeyEntity>("Template", cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Add a new API key.
+        /// </summary>
+        /// <param name="entity">The API key to add.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The API key, with server-allocated properties, such as <see cref="ApiKeyEntity.Token"/> (if server-allocated),
+        /// and <see cref="Entity.Id"/>, initialized.</returns>
+        /// <remarks>Leaving the token blank will cause the server to generate a cryptographically random API key token. After creation, the first
+        /// few characters of the token will be readable from <see cref="ApiKeyEntity.TokenPrefix"/>, but because only a cryptographically-secure
+        /// hash of the token is stored internally, the token itself cannot be retrieved.</remarks>
         public async Task<ApiKeyEntity> AddAsync(ApiKeyEntity entity, CancellationToken cancellationToken = default)
         {
             return await GroupCreateAsync<ApiKeyEntity, ApiKeyEntity>(entity, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Remove an existing API key.
+        /// </summary>
+        /// <param name="entity">The API key to remove.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>A task indicating completion.</returns>
         public async Task RemoveAsync(ApiKeyEntity entity, CancellationToken cancellationToken = default)
         {
             await Client.DeleteAsync(entity, "Self", entity, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Update an existing API key.
+        /// </summary>
+        /// <param name="entity">The API key to update.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>A task indicating completion.</returns>
+        /// <remarks>The API key token itself cannot be updated using this method.</remarks>
         public async Task UpdateAsync(ApiKeyEntity entity, CancellationToken cancellationToken = default)
         {
             await Client.PutAsync(entity, "Self", entity, cancellationToken: cancellationToken).ConfigureAwait(false);

--- a/src/Seq.Api/ResourceGroups/ApiResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/ApiResourceGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/ResourceGroups/ApiResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/ApiResourceGroup.cs
@@ -1,4 +1,18 @@
-﻿using System.Collections.Generic;
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Threading;
@@ -8,8 +22,12 @@ using Seq.Api.Model;
 
 namespace Seq.Api.ResourceGroups
 {
-    [DebuggerDisplay("{_name}")]
-    public class ApiResourceGroup
+    /// <summary>
+    /// Base class for resource groups representing portions of the Seq API. These wrap an underlying
+    /// <see cref="ResourceGroup"/> described in the API metadata at <c>/api/{resourceGroup}/resources</c>.
+    /// </summary>
+    [DebuggerDisplay("{" + nameof(_name) + "}")]
+    public abstract class ApiResourceGroup
     {
         readonly string _name;
         readonly ISeqConnection _connection;
@@ -20,78 +38,191 @@ namespace Seq.Api.ResourceGroups
             _connection = connection;
         }
 
+        /// <summary>
+        /// The API client used to access the API.
+        /// </summary>
         protected SeqApiClient Client => _connection.Client;
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns></returns>
         protected Task<ResourceGroup> LoadGroupAsync(CancellationToken cancellationToken = default)
         {
             return _connection.LoadResourceGroupAsync(_name, cancellationToken);
         }
 
+        /// <summary>
+        /// Get an entity.
+        /// </summary>
+        /// <typeparam name="TEntity">The entity type being operated upon.</typeparam>
+        /// <param name="link">The name of a link (or link template) included in the entity's link collection.</param>
+        /// <param name="parameters">Parameters that will be substituted into the operation's link template.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The entity.</returns>
         protected async Task<TEntity> GroupGetAsync<TEntity>(string link, IDictionary<string, object> parameters = null, CancellationToken cancellationToken = default)
         {
             var group = await LoadGroupAsync(cancellationToken).ConfigureAwait(false);
             return await Client.GetAsync<TEntity>(group, link, parameters, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Get a linked resource as a string.
+        /// </summary>
+        /// <param name="link">The name of a link (or link template) included in the entity's link collection.</param>
+        /// <param name="parameters">Parameters that will be substituted into the operation's link template.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The string.</returns>
         protected async Task<string> GroupGetStringAsync(string link, IDictionary<string, object> parameters = null, CancellationToken cancellationToken = default)
         {
             var group = await LoadGroupAsync(cancellationToken).ConfigureAwait(false);
             return await Client.GetStringAsync(group, link, parameters, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// List entities.
+        /// </summary>
+        /// <typeparam name="TEntity">The entity type being operated upon.</typeparam>
+        /// <param name="link">The name of a link (or link template) included in the entity's link collection.</param>
+        /// <param name="parameters">Parameters that will be substituted into the operation's link template.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The resulting entities.</returns>
         protected async Task<List<TEntity>> GroupListAsync<TEntity>(string link, IDictionary<string, object> parameters = null, CancellationToken cancellationToken = default)
         {
             var group = await LoadGroupAsync(cancellationToken).ConfigureAwait(false);
             return await Client.ListAsync<TEntity>(group, link, parameters, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Post/create an entity.
+        /// </summary>
+        /// <typeparam name="TEntity">The entity type being operated upon.</typeparam>
+        /// <param name="link">The name of a link (or link template) included in the entity's link collection.</param>
+        /// <param name="content">The content included in the operation.</param>
+        /// <param name="parameters">Parameters that will be substituted into the operation's link template.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>A task indicating completion.</returns>
         protected async Task GroupPostAsync<TEntity>(string link, TEntity content, IDictionary<string, object> parameters = null, CancellationToken cancellationToken = default)
         {
             var group = await LoadGroupAsync(cancellationToken).ConfigureAwait(false);
             await Client.PostAsync(group, link, content, parameters, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Post/create an entity and read the response as a string.
+        /// </summary>
+        /// <typeparam name="TEntity">The entity type being operated upon.</typeparam>
+        /// <param name="link">The name of a link (or link template) included in the entity's link collection.</param>
+        /// <param name="content">The content included in the operation.</param>
+        /// <param name="parameters">Parameters that will be substituted into the operation's link template.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The response string.</returns>
         protected async Task<string> GroupPostReadStringAsync<TEntity>(string link, TEntity content, IDictionary<string, object> parameters = null, CancellationToken cancellationToken = default)
         {
             var group = await LoadGroupAsync(cancellationToken).ConfigureAwait(false);
             return await Client.PostReadStringAsync(group, link, content, parameters, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Post/create an entity and read the response as a stream.
+        /// </summary>
+        /// <typeparam name="TEntity">The entity type being operated upon.</typeparam>
+        /// <param name="link">The name of a link (or link template) included in the entity's link collection.</param>
+        /// <param name="content">The content included in the operation.</param>
+        /// <param name="parameters">Parameters that will be substituted into the operation's link template.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The response stream.</returns>
         protected async Task<Stream> GroupPostReadBytesAsync<TEntity>(string link, TEntity content, IDictionary<string, object> parameters = null, CancellationToken cancellationToken = default)
         {
             var group = await LoadGroupAsync(cancellationToken).ConfigureAwait(false);
             return await Client.PostReadStreamAsync(group, link, content, parameters, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Post/create an entity.
+        /// </summary>
+        /// <typeparam name="TEntity">The entity type being operated upon.</typeparam>
+        /// <typeparam name="TResponse">The response type of the operation.</typeparam>
+        /// <param name="link">The name of a link (or link template) included in the entity's link collection.</param>
+        /// <param name="content">The content included in the operation.</param>
+        /// <param name="parameters">Parameters that will be substituted into the operation's link template.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The response type.</returns>
         protected async Task<TResponse> GroupPostAsync<TEntity, TResponse>(string link, TEntity content, IDictionary<string, object> parameters = null, CancellationToken cancellationToken = default)
         {
             var group = await LoadGroupAsync(cancellationToken).ConfigureAwait(false);
             return await Client.PostAsync<TEntity, TResponse>(group, link, content, parameters, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Update an entity.
+        /// </summary>
+        /// <typeparam name="TEntity">The entity type being operated upon.</typeparam>
+        /// <param name="link">The name of a link (or link template) included in the entity's link collection.</param>
+        /// <param name="content">The content included in the operation.</param>
+        /// <param name="parameters">Parameters that will be substituted into the operation's link template.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>A task indicating completion.</returns>
         protected async Task GroupPutAsync<TEntity>(string link, TEntity content, IDictionary<string, object> parameters = null, CancellationToken cancellationToken = default)
         {
             var group = await LoadGroupAsync(cancellationToken).ConfigureAwait(false);
             await Client.PutAsync(group, link, content, parameters, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Delete an entity.
+        /// </summary>
+        /// <typeparam name="TEntity">The entity type being operated upon.</typeparam>
+        /// <param name="link">The name of a link (or link template) included in the entity's link collection.</param>
+        /// <param name="content">The content included in the operation.</param>
+        /// <param name="parameters">Parameters that will be substituted into the operation's link template.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>A task indicating completion.</returns>
         protected async Task GroupDeleteAsync<TEntity>(string link, TEntity content, IDictionary<string, object> parameters = null, CancellationToken cancellationToken = default)
         {
             var group = await LoadGroupAsync(cancellationToken).ConfigureAwait(false);
             await Client.DeleteAsync(group, link, content, parameters, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Delete an entity.
+        /// </summary>
+        /// <typeparam name="TEntity">The entity type being operated upon.</typeparam>
+        /// <typeparam name="TResponse">The response type of the operation.</typeparam>
+        /// <param name="link">The name of a link (or link template) included in the entity's link collection.</param>
+        /// <param name="content">The content included in the operation.</param>
+        /// <param name="parameters">Parameters that will be substituted into the operation's link template.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The response type.</returns>
         protected async Task<TResponse> GroupDeleteAsync<TEntity, TResponse>(string link, TEntity content, IDictionary<string, object> parameters = null, CancellationToken cancellationToken = default)
         {
             var group = await LoadGroupAsync(cancellationToken).ConfigureAwait(false);
             return await Client.DeleteAsync<TEntity, TResponse>(group, link, content, parameters, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Get a URI from an entity's link collection.
+        /// </summary>
+        /// <typeparam name="TEntity">The entity type being operated upon.</typeparam>
+        /// <param name="entity"></param>
+        /// <param name="link">The name of a link (or link template) included in the entity's link collection.</param>
+        /// <param name="orElse">A default URI to use when no link with the given name is present.</param>
+        /// <returns>The link.</returns>
         protected string GetLink<TEntity>(TEntity entity, string link, string orElse) where TEntity : ILinked
         {
             return entity.Links.ContainsKey(link) ? link : orElse;
         }
 
+        /// <summary>
+        /// Create an entity.
+        /// </summary>
+        /// <typeparam name="TEntity">The entity type being operated upon.</typeparam>
+        /// <typeparam name="TResponse">The response type of the operation.</typeparam>
+        /// <param name="entity"></param>
+        /// <param name="parameters">Parameters that will be substituted into the operation's link template.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The response.</returns>
         protected async Task<TResponse> GroupCreateAsync<TEntity, TResponse>(TEntity entity,
             IDictionary<string, object> parameters = null, CancellationToken cancellationToken = default)
             where TEntity : ILinked

--- a/src/Seq.Api/ResourceGroups/AppInstancesResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/AppInstancesResourceGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -78,7 +78,7 @@ namespace Seq.Api.ResourceGroups
         public async Task<AppInstanceEntity> AddAsync(AppInstanceEntity entity, bool runOnExisting = false, CancellationToken cancellationToken = default)
         {
             if (entity == null) throw new ArgumentNullException(nameof(entity));
-            return await Client.PostAsync<AppInstanceEntity, AppInstanceEntity>(entity, "Create", entity, new Dictionary<string, object> { { "runOnExisting", runOnExisting } }, cancellationToken)
+            return await GroupCreateAsync<AppInstanceEntity, AppInstanceEntity>(entity, new Dictionary<string, object> { { "runOnExisting", runOnExisting } }, cancellationToken)
                 .ConfigureAwait(false);
         }
 

--- a/src/Seq.Api/ResourceGroups/AppInstancesResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/AppInstancesResourceGroup.cs
@@ -1,11 +1,31 @@
-﻿using System;
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Seq.Api.Model;
 using Seq.Api.Model.AppInstances;
+using Seq.Api.Model.Apps;
 
 namespace Seq.Api.ResourceGroups
 {
+    /// <summary>
+    /// Perform operations on app instances. App instances are individual processes based on a running <see cref="AppEntity"/> that can
+    /// read from and write to the Seq event stream.
+    /// </summary>
     public class AppInstancesResourceGroup : ApiResourceGroup
     {
         internal AppInstancesResourceGroup(ISeqConnection connection)
@@ -13,23 +33,48 @@ namespace Seq.Api.ResourceGroups
         {
         }
 
+        /// <summary>
+        /// Retrieve the app instance with the given id; throws if the entity does not exist.
+        /// </summary>
+        /// <param name="id">The id of the app instance.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The app instance.</returns>
         public async Task<AppInstanceEntity> FindAsync(string id, CancellationToken cancellationToken = default)
         {
             if (id == null) throw new ArgumentNullException(nameof(id));
             return await GroupGetAsync<AppInstanceEntity>("Item", new Dictionary<string, object> { { "id", id } }, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Retrieve app instances.
+        /// </summary>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>A list containing matching app instances.</returns>
         public async Task<List<AppInstanceEntity>> ListAsync(CancellationToken cancellationToken = default)
         {
             return await GroupListAsync<AppInstanceEntity>("Items", cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Construct an app instance with appropriate app settings and server defaults pre-initialized.
+        /// </summary>
+        /// <param name="appId">The id of the <see cref="AppEntity"/> to create an instance of.</param>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The unsaved app instance.</returns>
         public async Task<AppInstanceEntity> TemplateAsync(string appId, CancellationToken cancellationToken = default)
         {
             if (appId == null) throw new ArgumentNullException(nameof(appId));
             return await GroupGetAsync<AppInstanceEntity>("Template", new Dictionary<string, object> { { "appId", appId } }, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Add a new app instance.
+        /// </summary>
+        /// <param name="entity">The app instance to add.</param>
+        /// <param name="runOnExisting">If <c>true</c>, events already on the server will be sent to the app. Note that this requires disk buffering and persistent bookmarks
+        /// for the app, which is not recommended for performance reasons.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The app instance, with server-allocated properties such as <see cref="Entity.Id"/> initialized.</returns>
         public async Task<AppInstanceEntity> AddAsync(AppInstanceEntity entity, bool runOnExisting = false, CancellationToken cancellationToken = default)
         {
             if (entity == null) throw new ArgumentNullException(nameof(entity));
@@ -37,18 +82,38 @@ namespace Seq.Api.ResourceGroups
                 .ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Remove an existing app instance.
+        /// </summary>
+        /// <param name="entity">The app instance to remove.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>A task indicating completion.</returns>
         public async Task RemoveAsync(AppInstanceEntity entity, CancellationToken cancellationToken = default)
         {
             if (entity == null) throw new ArgumentNullException(nameof(entity));
             await Client.DeleteAsync(entity, "Self", entity, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Update an existing app instance.
+        /// </summary>
+        /// <param name="entity">The app instance to update.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>A task indicating completion.</returns>
         public async Task UpdateAsync(AppInstanceEntity entity, CancellationToken cancellationToken = default)
         {
             if (entity == null) throw new ArgumentNullException(nameof(entity));
             await Client.PutAsync(entity, "Self", entity, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Send the event with id <paramref name="eventId"/> to the app instance <paramref name="entity"/>.
+        /// </summary>
+        /// <param name="entity">The app instance to invoke.</param>
+        /// <param name="eventId">The id of an event to send to the app.</param>
+        /// <param name="settingOverrides">Values for any overridable settings exposed by the app instance.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>A task indicating completion.</returns>
         public async Task InvokeAsync(AppInstanceEntity entity, string eventId, IReadOnlyDictionary<string, string> settingOverrides, CancellationToken cancellationToken = default)
         {
             if (entity == null) throw new ArgumentNullException(nameof(entity));

--- a/src/Seq.Api/ResourceGroups/AppInstancesResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/AppInstancesResourceGroup.cs
@@ -19,6 +19,7 @@ using System.Threading.Tasks;
 using Seq.Api.Model;
 using Seq.Api.Model.AppInstances;
 using Seq.Api.Model.Apps;
+using Seq.Api.Model.Diagnostics;
 
 namespace Seq.Api.ResourceGroups
 {
@@ -121,6 +122,19 @@ namespace Seq.Api.ResourceGroups
 
             var postedSettings = settingOverrides ?? new Dictionary<string, string>();
             await Client.PostAsync(entity, "Invoke", postedSettings, new Dictionary<string, object>{{"eventId", eventId}}, cancellationToken);
+        }
+        
+        /// <summary>
+        /// Retrieve a detailed metric for the app instance.
+        /// </summary>
+        /// <param name="entity">The app instance to retrieve metrics for.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <param name="measurement">The measurement to get.</param>
+        /// <returns></returns>
+        public async Task<MeasurementTimeseriesPart> GetMeasurementTimeseriesAsync(AppInstanceEntity entity, string measurement, CancellationToken cancellationToken = default)
+        {
+            var parameters = new Dictionary<string, object>{ ["id"] = entity.Id, ["measurement"] = measurement };
+            return await GroupGetAsync<MeasurementTimeseriesPart>("Metric", parameters, cancellationToken);
         }
     }
 }

--- a/src/Seq.Api/ResourceGroups/AppsResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/AppsResourceGroup.cs
@@ -1,11 +1,29 @@
-﻿using System;
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Seq.Api.Model;
 using Seq.Api.Model.Apps;
 
 namespace Seq.Api.ResourceGroups
 {
+    /// <summary>
+    /// Perform operations on Seq apps. Seq apps are executable plug-ins that read from and write to the Seq event stream.
+    /// </summary>
     public class AppsResourceGroup : ApiResourceGroup
     {
         internal AppsResourceGroup(ISeqConnection connection)
@@ -13,37 +31,79 @@ namespace Seq.Api.ResourceGroups
         {
         }
 
+        /// <summary>
+        /// Retrieve the app with the given id; throws if the entity does not exist.
+        /// </summary>
+        /// <param name="id">The id of the app.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The app.</returns>
         public async Task<AppEntity> FindAsync(string id, CancellationToken cancellationToken = default)
         {
             if (id == null) throw new ArgumentNullException(nameof(id));
             return await GroupGetAsync<AppEntity>("Item", new Dictionary<string, object> { { "id", id } }, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Retrieve apps.
+        /// </summary>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>A list containing matching apps.</returns>
         public async Task<List<AppEntity>> ListAsync(CancellationToken cancellationToken = default)
         {
             return await GroupListAsync<AppEntity>("Items", cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Construct an app with server defaults pre-initialized.
+        /// </summary>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The unsaved app.</returns>
         public async Task<AppEntity> TemplateAsync(CancellationToken cancellationToken = default)
         {
             return await GroupGetAsync<AppEntity>("Template", cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Add a new app.
+        /// </summary>
+        /// <param name="entity">The app to add.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The app, with server-allocated properties such as <see cref="Entity.Id"/> initialized.</returns>
         public async Task<AppEntity> AddAsync(AppEntity entity, CancellationToken cancellationToken = default)
         {
             return await Client.PostAsync<AppEntity, AppEntity>(entity, "Create", entity, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Remove an existing app.
+        /// </summary>
+        /// <param name="entity">The app to remove.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>A task indicating completion.</returns>
         public async Task RemoveAsync(AppEntity entity, CancellationToken cancellationToken = default)
         {
             await Client.DeleteAsync(entity, "Self", entity, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Update an existing app.
+        /// </summary>
+        /// <param name="entity">The app to update.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>A task indicating completion.</returns>
         public async Task UpdateAsync(AppEntity entity, CancellationToken cancellationToken = default)
         {
             await Client.PutAsync(entity, "Self", entity, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Create a new app by installing a NuGet package.
+        /// </summary>
+        /// <param name="feedId">The feed from which to retrieve the package.</param>
+        /// <param name="packageId">The package id, for example <c>Seq.App.JsonArchive</c>.</param>
+        /// <param name="version">The version of the package to install. If <c>null</c>, the latest version of the package will be installed.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The resulting app.</returns>
         public async Task<AppEntity> InstallPackageAsync(string feedId, string packageId, string version = null, CancellationToken cancellationToken = default)
         {
             if (feedId == null) throw new ArgumentNullException(nameof(feedId));
@@ -53,6 +113,13 @@ namespace Seq.Api.ResourceGroups
             return await GroupPostAsync<object, AppEntity>("InstallPackage", new object(), parameters, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Update the underlying package for app <paramref name="entity"/>.
+        /// </summary>
+        /// <param name="entity">The app to update the package for.</param>
+        /// <param name="version">The version to update to; if <c>null</c>, the latest available version in the feed will be used.</param>
+        /// <param name="force">If <c>true</c>, update the app package even if the same version is already installed.</param>
+        /// <returns>The app with updated package information.</returns>
         public async Task<AppEntity> UpdatePackageAsync(AppEntity entity, string version = null, bool force = false)
         {
             if (entity == null) throw new ArgumentNullException(nameof(entity));

--- a/src/Seq.Api/ResourceGroups/AppsResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/AppsResourceGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -71,7 +71,7 @@ namespace Seq.Api.ResourceGroups
         /// <returns>The app, with server-allocated properties such as <see cref="Entity.Id"/> initialized.</returns>
         public async Task<AppEntity> AddAsync(AppEntity entity, CancellationToken cancellationToken = default)
         {
-            return await Client.PostAsync<AppEntity, AppEntity>(entity, "Create", entity, cancellationToken: cancellationToken).ConfigureAwait(false);
+            return await GroupCreateAsync<AppEntity, AppEntity>(entity, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/Seq.Api/ResourceGroups/BackupsResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/BackupsResourceGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/ResourceGroups/BackupsResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/BackupsResourceGroup.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
@@ -7,6 +21,10 @@ using Seq.Api.Model.Backups;
 
 namespace Seq.Api.ResourceGroups
 {
+    /// <summary>
+    /// Perform operations on backups. Seq backups include metadata like users, signals, API keys and other configuration, but do not include
+    /// the event stream. Backups are fully encrypted with AES-256 and cannot be restored without the master key from the originating Seq instance.
+    /// </summary>
     public class BackupsResourceGroup : ApiResourceGroup
     {
         internal BackupsResourceGroup(ISeqConnection connection)
@@ -14,17 +32,33 @@ namespace Seq.Api.ResourceGroups
         {
         }
 
+        /// <summary>
+        /// Retrieve the backup with the given id; throws if the entity does not exist.
+        /// </summary>
+        /// <param name="id">The id of the backup.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The backup.</returns>
         public async Task<BackupEntity> FindAsync(string id, CancellationToken cancellationToken = default)
         {
             if (id == null) throw new ArgumentNullException(nameof(id));
             return await GroupGetAsync<BackupEntity>("Item", new Dictionary<string, object> { { "id", id } }, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Retrieve backups.
+        /// </summary>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>A list containing matching backups.</returns>
         public async Task<List<BackupEntity>> ListAsync(CancellationToken cancellationToken = default)
         {
             return await GroupListAsync<BackupEntity>("Items", cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Download a backup with the current state of the server. Note that the backup will not be stored server-side.
+        /// </summary>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The <c>.seqbak</c> backup file.</returns>
         public async Task<Stream> DownloadImmediateAsync(CancellationToken cancellationToken = default)
         {
             return await GroupPostReadBytesAsync("Immediate", new object(), cancellationToken: cancellationToken).ConfigureAwait(false);

--- a/src/Seq.Api/ResourceGroups/DashboardsResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/DashboardsResourceGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/ResourceGroups/DashboardsResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/DashboardsResourceGroup.cs
@@ -1,11 +1,30 @@
-﻿using System;
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Seq.Api.Model;
 using Seq.Api.Model.Monitoring;
+using Seq.Api.Model.Users;
 
 namespace Seq.Api.ResourceGroups
 {
+    /// <summary>
+    /// Perform operations on dashboards. Dashboards are collections of charts and alerts that are either shared or user-specific.
+    /// </summary>
     public class DashboardsResourceGroup : ApiResourceGroup
     {
         internal DashboardsResourceGroup(ISeqConnection connection)
@@ -13,33 +32,70 @@ namespace Seq.Api.ResourceGroups
         {
         }
 
+        /// <summary>
+        /// Retrieve the dashboard with the given id; throws if the entity does not exist.
+        /// </summary>
+        /// <param name="id">The id of the dashboard.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The dashboard.</returns>
         public async Task<DashboardEntity> FindAsync(string id, CancellationToken cancellationToken = default)
         {
             if (id == null) throw new ArgumentNullException(nameof(id));
             return await GroupGetAsync<DashboardEntity>("Item", new Dictionary<string, object> { { "id", id } }, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Retrieve dashboards.
+        /// </summary>
+        /// <param name="ownerId">If the id of a <see cref="UserEntity"/> is provided, only dashboards owned by them will be included in the result; if
+        /// not specified, personal dashboards for all owners will be listed.</param>
+        /// <param name="shared">If <c>true</c>, shared dashboards will be included in the result.</param>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>A list containing matching dashboards.</returns>
         public async Task<List<DashboardEntity>> ListAsync(string ownerId = null, bool shared = false, CancellationToken cancellationToken = default)
         {
             var parameters = new Dictionary<string, object> { { "ownerId", ownerId }, { "shared", shared } };
             return await GroupListAsync<DashboardEntity>("Items", parameters, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Construct a dashboard with server defaults pre-initialized.
+        /// </summary>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The unsaved dashboard.</returns>
         public async Task<DashboardEntity> TemplateAsync(CancellationToken cancellationToken = default)
         {
             return await GroupGetAsync<DashboardEntity>("Template", cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Add a new dashboard.
+        /// </summary>
+        /// <param name="entity">The dashboard to add.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The dashboard, with server-allocated properties such as <see cref="Entity.Id"/> initialized.</returns>
         public async Task<DashboardEntity> AddAsync(DashboardEntity entity, CancellationToken cancellationToken = default)
         {
             return await GroupCreateAsync<DashboardEntity, DashboardEntity>(entity, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Remove an existing dashboard.
+        /// </summary>
+        /// <param name="entity">The dashboard to remove.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>A task indicating completion.</returns>
         public async Task RemoveAsync(DashboardEntity entity, CancellationToken cancellationToken = default)
         {
             await Client.DeleteAsync(entity, "Self", entity, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Update an existing dashboard.
+        /// </summary>
+        /// <param name="entity">The dashboard to update.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>A task indicating completion.</returns>
         public async Task UpdateAsync(DashboardEntity entity, CancellationToken cancellationToken = default)
         {
             await Client.PutAsync(entity, "Self", entity, cancellationToken: cancellationToken).ConfigureAwait(false);

--- a/src/Seq.Api/ResourceGroups/DataResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/DataResourceGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/ResourceGroups/DataResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/DataResourceGroup.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -7,6 +21,9 @@ using Seq.Api.Model.Signals;
 
 namespace Seq.Api.ResourceGroups
 {
+    /// <summary>
+    /// Execute SQL-style queries against the API.
+    /// </summary>
     public class DataResourceGroup : ApiResourceGroup
     {
         internal DataResourceGroup(ISeqConnection connection)

--- a/src/Seq.Api/ResourceGroups/DiagnosticsResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/DiagnosticsResourceGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/ResourceGroups/DiagnosticsResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/DiagnosticsResourceGroup.cs
@@ -12,9 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Seq.Api.Model.Diagnostics;
+using Seq.Api.Model.Inputs;
 
 namespace Seq.Api.ResourceGroups
 {
@@ -56,6 +58,18 @@ namespace Seq.Api.ResourceGroups
         public async Task<string> GetIngestionLogAsync(CancellationToken cancellationToken = default)
         {
             return await GroupGetStringAsync("IngestionLog", cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+        
+        /// <summary>
+        /// Retrieve a detailed system metric.
+        /// </summary>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <param name="measurement">The measurement to get.</param>
+        /// <returns></returns>
+        public async Task<MeasurementTimeseriesPart> GetMeasurementTimeseriesAsync(string measurement, CancellationToken cancellationToken = default)
+        {
+            var parameters = new Dictionary<string, object>{ ["measurement"] = measurement };
+            return await GroupGetAsync<MeasurementTimeseriesPart>("Metric", parameters, cancellationToken);
         }
     }
 }

--- a/src/Seq.Api/ResourceGroups/DiagnosticsResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/DiagnosticsResourceGroup.cs
@@ -1,9 +1,26 @@
-﻿using System.Threading;
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Threading;
 using System.Threading.Tasks;
 using Seq.Api.Model.Diagnostics;
 
 namespace Seq.Api.ResourceGroups
 {
+    /// <summary>
+    /// Access server diagnostics.
+    /// </summary>
     public class DiagnosticsResourceGroup : ApiResourceGroup
     {
         internal DiagnosticsResourceGroup(ISeqConnection connection)
@@ -11,16 +28,31 @@ namespace Seq.Api.ResourceGroups
         {
         }
 
+        /// <summary>
+        /// Retrieve the current server metrics, including memory usage, ingestion rates, disk consumption, etc.
+        /// </summary>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>Current server metrics.</returns>
         public async Task<ServerMetricsEntity> GetServerMetricsAsync(CancellationToken cancellationToken = default)
         {
             return await GroupGetAsync<ServerMetricsEntity>("ServerMetrics", cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Retrieve status messages describing the state of the server.
+        /// </summary>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>Status messages.</returns>
         public async Task<ServerStatusPart> GetServerStatusAsync(CancellationToken cancellationToken = default)
         {
             return await GroupGetAsync<ServerStatusPart>("ServerStatus", cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Retrieve the server ingestion log, including information about failed event ingestion.
+        /// </summary>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The server ingestion log.</returns>
         public async Task<string> GetIngestionLogAsync(CancellationToken cancellationToken = default)
         {
             return await GroupGetStringAsync("IngestionLog", cancellationToken: cancellationToken).ConfigureAwait(false);

--- a/src/Seq.Api/ResourceGroups/EventsResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/EventsResourceGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/ResourceGroups/EventsResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/EventsResourceGroup.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -10,6 +24,9 @@ using Seq.Api.Streams;
 
 namespace Seq.Api.ResourceGroups
 {
+    /// <summary>
+    /// Read and subscribe to events from the event store.
+    /// </summary>
     public class EventsResourceGroup : ApiResourceGroup
     {
         internal EventsResourceGroup(ISeqConnection connection)

--- a/src/Seq.Api/ResourceGroups/EventsResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/EventsResourceGroup.cs
@@ -247,7 +247,7 @@ namespace Seq.Api.ResourceGroups
         }
 
         /// <summary>
-        /// Connect to the live event stream. Dispose the resulting stream to disconnect.
+        /// Connect to the live event stream, read as strongly-typed objects. Dispose the resulting stream to disconnect.
         /// </summary>
         /// <typeparam name="T">The type into which events should be deserialized.</typeparam>
         /// <param name="signal">If provided, a signal expression describing the set of events that will be filtered for the result.</param>
@@ -256,6 +256,8 @@ namespace Seq.Api.ResourceGroups
         /// <param name="cancellationToken">Token through which the operation can be cancelled.</param>
         /// <returns>An observable that will stream events from the server to subscribers. Events will be buffered server-side until the first
         /// subscriber connects, ensure at least one subscription is made in order to avoid event loss.</returns>
+        /// <remarks>See <a href="https://docs.datalust.co/docs/posting-raw-events#section-compact-json-format">the Seq ingestion
+        /// docs</a> for event schema information.</remarks>
         public async Task<ObservableStream<T>> StreamAsync<T>(
             SignalExpressionPart signal = null,
             string filter = null,
@@ -270,8 +272,7 @@ namespace Seq.Api.ResourceGroups
         }
 
         /// <summary>
-        /// Retrieve a list of events that match a set of conditions. The complete result is buffered into memory,
-        /// so if a large result set is expected, use InSignalAsync() and lastReadEventId to page the results.
+        /// Connect to the live event stream, read as raw JSON documents. Dispose the resulting stream to disconnect.
         /// </summary>
         /// <param name="signal">If provided, a signal expression describing the set of events that will be filtered for the result.</param>
         /// <param name="filter">A strict Seq filter expression to match (text expressions must be in double quotes). To
@@ -279,6 +280,8 @@ namespace Seq.Api.ResourceGroups
         /// <param name="cancellationToken">Token through which the operation can be cancelled.</param>
         /// <returns>An observable that will stream events from the server to subscribers. Events will be buffered server-side until the first
         /// subscriber connects, ensure at least one subscription is made in order to avoid event loss.</returns>
+        /// <remarks>See <a href="https://docs.datalust.co/docs/posting-raw-events#section-compact-json-format">the Seq ingestion
+        /// docs</a> for event schema information.</remarks>
         public async Task<ObservableStream<string>> StreamDocumentsAsync(
             SignalExpressionPart signal = null,
             string filter = null,

--- a/src/Seq.Api/ResourceGroups/ExpressionsResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/ExpressionsResourceGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/ResourceGroups/ExpressionsResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/ExpressionsResourceGroup.cs
@@ -1,10 +1,27 @@
-﻿using System.Collections.Generic;
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Seq.Api.Model.Expressions;
 
 namespace Seq.Api.ResourceGroups
 {
+    /// <summary>
+    /// Perform operations on queries and filter expressions.
+    /// </summary>
     public class ExpressionsResourceGroup : ApiResourceGroup
     {
         internal ExpressionsResourceGroup(ISeqConnection connection)
@@ -12,6 +29,13 @@ namespace Seq.Api.ResourceGroups
         {
         }
 
+        /// <summary>
+        /// Convert an expression in the relaxed syntax supported by the filter bar, to the strictly-valid
+        /// syntax required by API interactions.
+        /// </summary>
+        /// <param name="fuzzy">The (potentially) relaxed-syntax expression.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The expression in a strictly-valid form.</returns>
         public Task<ExpressionPart> ToStrictAsync(string fuzzy, CancellationToken cancellationToken = default)
         {
             return GroupGetAsync<ExpressionPart>("ToStrict", new Dictionary<string, object>
@@ -20,6 +44,13 @@ namespace Seq.Api.ResourceGroups
             }, cancellationToken);
         }
 
+        /// <summary>
+        /// Convert an expression in the relaxed syntax supported by the filter bar, to the strict and limited
+        /// syntax required within SQL queries.
+        /// </summary>
+        /// <param name="fuzzy">The (potentially) relaxed-syntax expression.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The expression in a form that can be used within SQL queries.</returns>
         public Task<ExpressionPart> ToSqlAsync(string fuzzy, CancellationToken cancellationToken = default)
         {
             return GroupGetAsync<ExpressionPart>("ToSql", new Dictionary<string, object>

--- a/src/Seq.Api/ResourceGroups/FeedsResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/FeedsResourceGroup.cs
@@ -1,11 +1,29 @@
-﻿using System;
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Seq.Api.Model;
 using Seq.Api.Model.Feeds;
 
 namespace Seq.Api.ResourceGroups
 {
+    /// <summary>
+    /// Perform operations on NuGet feeds.
+    /// </summary>
     public class FeedsResourceGroup : ApiResourceGroup
     {
         internal FeedsResourceGroup(ISeqConnection connection)
@@ -13,32 +31,66 @@ namespace Seq.Api.ResourceGroups
         {
         }
 
+        /// <summary>
+        /// Retrieve the feed with the given id; throws if the entity does not exist.
+        /// </summary>
+        /// <param name="id">The id of the feed.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The feed.</returns>
         public async Task<NuGetFeedEntity> FindAsync(string id, CancellationToken cancellationToken = default)
         {
             if (id == null) throw new ArgumentNullException(nameof(id));
             return await GroupGetAsync<NuGetFeedEntity>("Item", new Dictionary<string, object> { { "id", id } }, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Retrieve feeds.
+        /// </summary>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>A list containing matching feeds.</returns>
         public async Task<List<NuGetFeedEntity>> ListAsync(CancellationToken cancellationToken = default)
         {
             return await GroupListAsync<NuGetFeedEntity>("Items", cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Construct a feed with server defaults pre-initialized.
+        /// </summary>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The unsaved feed.</returns>
         public async Task<NuGetFeedEntity> TemplateAsync(CancellationToken cancellationToken = default)
         {
             return await GroupGetAsync<NuGetFeedEntity>("Template", cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Add a new feed.
+        /// </summary>
+        /// <param name="entity">The feed to add.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The feed, with server-allocated properties such as <see cref="Entity.Id"/> initialized.</returns>
         public async Task<NuGetFeedEntity> AddAsync(NuGetFeedEntity entity, CancellationToken cancellationToken = default)
         {
             return await Client.PostAsync<NuGetFeedEntity, NuGetFeedEntity>(entity, "Create", entity, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Remove an existing feed.
+        /// </summary>
+        /// <param name="entity">The feed to remove.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>A task indicating completion.</returns>
         public async Task RemoveAsync(NuGetFeedEntity entity, CancellationToken cancellationToken = default)
         {
             await Client.DeleteAsync(entity, "Self", entity, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Update an existing feed.
+        /// </summary>
+        /// <param name="entity">The feed to update.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>A task indicating completion.</returns>
         public async Task UpdateAsync(NuGetFeedEntity entity, CancellationToken cancellationToken = default)
         {
             await Client.PutAsync(entity, "Self", entity, cancellationToken: cancellationToken).ConfigureAwait(false);

--- a/src/Seq.Api/ResourceGroups/FeedsResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/FeedsResourceGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -71,7 +71,7 @@ namespace Seq.Api.ResourceGroups
         /// <returns>The feed, with server-allocated properties such as <see cref="Entity.Id"/> initialized.</returns>
         public async Task<NuGetFeedEntity> AddAsync(NuGetFeedEntity entity, CancellationToken cancellationToken = default)
         {
-            return await Client.PostAsync<NuGetFeedEntity, NuGetFeedEntity>(entity, "Create", entity, cancellationToken: cancellationToken).ConfigureAwait(false);
+            return await GroupCreateAsync<NuGetFeedEntity, NuGetFeedEntity>(entity, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/Seq.Api/ResourceGroups/ISeqConnection.cs
+++ b/src/Seq.Api/ResourceGroups/ISeqConnection.cs
@@ -1,3 +1,17 @@
+// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 using System.Threading;
 using System.Threading.Tasks;
 using Seq.Api.Client;

--- a/src/Seq.Api/ResourceGroups/ISeqConnection.cs
+++ b/src/Seq.Api/ResourceGroups/ISeqConnection.cs
@@ -1,4 +1,4 @@
-// Copyright 2014-2019 Datalust and contributors. 
+// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/ResourceGroups/LicensesResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/LicensesResourceGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/ResourceGroups/LicensesResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/LicensesResourceGroup.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -6,6 +20,9 @@ using Seq.Api.Model.License;
 
 namespace Seq.Api.ResourceGroups
 {
+    /// <summary>
+    /// Perform operations on the Seq license certificate.
+    /// </summary>
     public class LicensesResourceGroup : ApiResourceGroup
     {
         internal LicensesResourceGroup(ISeqConnection connection)
@@ -13,27 +30,54 @@ namespace Seq.Api.ResourceGroups
         {
         }
 
+        /// <summary>
+        /// Retrieve the license with the given id; throws if the entity does not exist.
+        /// </summary>
+        /// <param name="id">The id of the license.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The license.</returns>
         public async Task<LicenseEntity> FindAsync(string id, CancellationToken cancellationToken = default)
         {
             if (id == null) throw new ArgumentNullException(nameof(id));
             return await GroupGetAsync<LicenseEntity>("Item", new Dictionary<string, object> { { "id", id } }, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Retrieve the license being used by the server.
+        /// </summary>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The license.</returns>
         public async Task<LicenseEntity> FindCurrentAsync(CancellationToken cancellationToken = default)
         {
             return await GroupGetAsync<LicenseEntity>("Current", cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Retrieve licenses.
+        /// </summary>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>A list containing matching licenses.</returns>
         public async Task<List<LicenseEntity>> ListAsync(CancellationToken cancellationToken = default)
         {
             return await GroupListAsync<LicenseEntity>("Items", cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Update an existing license.
+        /// </summary>
+        /// <param name="entity">The license to update.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>A task indicating completion.</returns>
         public async Task UpdateAsync(LicenseEntity entity, CancellationToken cancellationToken = default)
         {
             await Client.PutAsync(entity, "Self", entity, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Remove the current license, causing the server to fall back to the default configuration.
+        /// </summary>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>A task indicating completion.</returns>
         public async Task DowngradeAsync(CancellationToken cancellationToken = default)
         {
             await GroupPostAsync("Downgrade", new object(), cancellationToken: cancellationToken).ConfigureAwait(false);

--- a/src/Seq.Api/ResourceGroups/PermalinksResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/PermalinksResourceGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/ResourceGroups/PermalinksResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/PermalinksResourceGroup.cs
@@ -1,11 +1,30 @@
-﻿using System;
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Seq.Api.Model;
 using Seq.Api.Model.Permalinks;
+using Seq.Api.Model.Users;
 
 namespace Seq.Api.ResourceGroups
 {
+    /// <summary>
+    /// Perform operations on permalinked events.
+    /// </summary>
     public class PermalinksResourceGroup : ApiResourceGroup
     {
         internal PermalinksResourceGroup(ISeqConnection connection)
@@ -13,6 +32,15 @@ namespace Seq.Api.ResourceGroups
         {
         }
 
+        /// <summary>
+        /// Retrieve the permalink with the given id; throws if the entity does not exist.
+        /// </summary>
+        /// <param name="id">The id of the permalink.</param>
+        /// <param name="renderEvent">If <c>true</c> and <paramref name="includeEvent"/> is <c>true</c>, then the rendered message will be included in the event; otherwise, event
+        /// information will include the message template only.</param>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <param name="includeEvent">If <c>true</c>, the event payload will be returned along with permalink metadata; otherwise, only metadata will be returned.</param>
+        /// <returns>The permalink.</returns>
         public async Task<PermalinkEntity> FindAsync(
             string id,
             bool includeEvent = false,
@@ -29,7 +57,18 @@ namespace Seq.Api.ResourceGroups
             return await GroupGetAsync<PermalinkEntity>("Item", parameters, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Retrieve permalinks.
+        /// </summary>
+        /// <param name="ownerId">If the id of a <see cref="UserEntity"/> is provided, only permalinks owned by them will be included in the result; if
+        /// not specified, permalinks for all owners will be listed.</param>
+        /// <param name="renderEvent">If <c>true</c> and <paramref name="includeEvent"/> is <c>true</c>, then the rendered message will be included in the event; otherwise, event
+        /// information will include the message template only.</param>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <param name="includeEvent">If <c>true</c>, the event payload will be returned along with permalink metadata; otherwise, only metadata will be returned.</param>
+        /// <returns>A list containing matching permalinks.</returns>
         public async Task<List<PermalinkEntity>> ListAsync(
+            string ownerId = null,
             bool includeEvent = false,
             bool renderEvent = false,
             CancellationToken cancellationToken = default)
@@ -37,27 +76,51 @@ namespace Seq.Api.ResourceGroups
             var parameters = new Dictionary<string, object>
             {
                 {"includeEvent", includeEvent},
-                {"renderEvent", renderEvent}
+                {"renderEvent", renderEvent},
+                { "ownerId", ownerId }
             };
 
             return await GroupListAsync<PermalinkEntity>("Items", parameters, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Construct a permalink with server defaults pre-initialized.
+        /// </summary>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The unsaved permalink.</returns>
         public async Task<PermalinkEntity> TemplateAsync(CancellationToken cancellationToken = default)
         {
             return await GroupGetAsync<PermalinkEntity>("Template", cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Add a new permalink.
+        /// </summary>
+        /// <param name="entity">The permalink to add.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The permalink, with server-allocated properties such as <see cref="Entity.Id"/> initialized.</returns>
         public async Task<PermalinkEntity> AddAsync(PermalinkEntity entity, CancellationToken cancellationToken = default)
         {
             return await GroupCreateAsync<PermalinkEntity, PermalinkEntity>(entity, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Remove an existing permalink.
+        /// </summary>
+        /// <param name="entity">The permalink to remove.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>A task indicating completion.</returns>
         public async Task RemoveAsync(PermalinkEntity entity, CancellationToken cancellationToken = default)
         {
             await Client.DeleteAsync(entity, "Self", entity, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Update an existing permalink.
+        /// </summary>
+        /// <param name="entity">The permalink to update.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>A task indicating completion.</returns>
         public async Task UpdateAsync(PermalinkEntity entity, CancellationToken cancellationToken = default)
         {
             await Client.PutAsync(entity, "Self", entity, cancellationToken: cancellationToken).ConfigureAwait(false);

--- a/src/Seq.Api/ResourceGroups/RetentionPoliciesResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/RetentionPoliciesResourceGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/ResourceGroups/RetentionPoliciesResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/RetentionPoliciesResourceGroup.cs
@@ -1,11 +1,29 @@
-﻿using System;
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Seq.Api.Model;
 using Seq.Api.Model.Retention;
 
 namespace Seq.Api.ResourceGroups
 {
+    /// <summary>
+    /// Perform operations on retention policies.
+    /// </summary>
     public class RetentionPoliciesResourceGroup : ApiResourceGroup
     {
         internal RetentionPoliciesResourceGroup(ISeqConnection connection)
@@ -13,32 +31,66 @@ namespace Seq.Api.ResourceGroups
         {
         }
 
+        /// <summary>
+        /// Retrieve the retention policy with the given id; throws if the entity does not exist.
+        /// </summary>
+        /// <param name="id">The id of the retention policy.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The retention policy.</returns>
         public async Task<RetentionPolicyEntity> FindAsync(string id, CancellationToken cancellationToken = default)
         {
             if (id == null) throw new ArgumentNullException(nameof(id));
             return await GroupGetAsync<RetentionPolicyEntity>("Item", new Dictionary<string, object> { { "id", id } }, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Retrieve retention policies.
+        /// </summary>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>A list containing matching retention policies.</returns>
         public async Task<List<RetentionPolicyEntity>> ListAsync(CancellationToken cancellationToken = default)
         {
             return await GroupListAsync<RetentionPolicyEntity>("Items", cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Construct a retention policy with server defaults pre-initialized.
+        /// </summary>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The unsaved retention policy.</returns>
         public async Task<RetentionPolicyEntity> TemplateAsync(CancellationToken cancellationToken = default)
         {
             return await GroupGetAsync<RetentionPolicyEntity>("Template", cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Add a new retention policy.
+        /// </summary>
+        /// <param name="entity">The retention policy to add.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The retention policy, with server-allocated properties such as <see cref="Entity.Id"/> initialized.</returns>
         public async Task<RetentionPolicyEntity> AddAsync(RetentionPolicyEntity entity, CancellationToken cancellationToken = default)
         {
             return await GroupCreateAsync<RetentionPolicyEntity, RetentionPolicyEntity>(entity, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Remove an existing retention policy.
+        /// </summary>
+        /// <param name="entity">The retention policy to remove.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>A task indicating completion.</returns>
         public async Task RemoveAsync(RetentionPolicyEntity entity, CancellationToken cancellationToken = default)
         {
             await Client.DeleteAsync(entity, "Self", entity, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Update an existing retention policy.
+        /// </summary>
+        /// <param name="entity">The retention policy to update.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>A task indicating completion.</returns>
         public async Task UpdateAsync(RetentionPolicyEntity entity, CancellationToken cancellationToken = default)
         {
             await Client.PutAsync(entity, "Self", entity, cancellationToken: cancellationToken).ConfigureAwait(false);

--- a/src/Seq.Api/ResourceGroups/RolesResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/RolesResourceGroup.cs
@@ -1,0 +1,55 @@
+﻿// Copyright 2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Threading;
+using Seq.Api.Model.Security;
+
+namespace Seq.Api.ResourceGroups
+{
+    /// <summary>
+    /// Perform operations on user roles.
+    /// </summary>
+    public class RolesResourceGroup : ApiResourceGroup
+    {
+        internal RolesResourceGroup(ISeqConnection connection)
+            : base("Roles", connection)
+        {
+        }
+
+        /// <summary>
+        /// Find a role given its id.
+        /// </summary>
+        /// <param name="id">The id of a role to find.</param>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The matching role.</returns>
+        public async Task<RoleEntity> FindAsync(string id, CancellationToken cancellationToken = default)
+        {
+            if (id == null) throw new ArgumentNullException(nameof(id));
+            return await GroupGetAsync<RoleEntity>("Item", new Dictionary<string, object> { { "id", id } }, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// List all roles.
+        /// </summary>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>A list containing all roles available on the server.</returns>
+        public async Task<List<RoleEntity>> ListAsync(CancellationToken cancellationToken = default)
+        {
+            return await GroupListAsync<RoleEntity>("Items", cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Seq.Api/ResourceGroups/RolesResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/RolesResourceGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/ResourceGroups/RolesResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/RolesResourceGroup.cs
@@ -31,11 +31,11 @@ namespace Seq.Api.ResourceGroups
         }
 
         /// <summary>
-        /// Find a role given its id.
+        /// Retrieve the role with the given id; throws if the entity does not exist.
         /// </summary>
-        /// <param name="id">The id of a role to find.</param>
-        /// <param name="cancellationToken"><see cref="CancellationToken"/> allowing the operation to be canceled.</param>
-        /// <returns>The matching role.</returns>
+        /// <param name="id">The id of the role.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The role.</returns>
         public async Task<RoleEntity> FindAsync(string id, CancellationToken cancellationToken = default)
         {
             if (id == null) throw new ArgumentNullException(nameof(id));
@@ -43,7 +43,7 @@ namespace Seq.Api.ResourceGroups
         }
 
         /// <summary>
-        /// List all roles.
+        /// Retrieve roles.
         /// </summary>
         /// <param name="cancellationToken"><see cref="CancellationToken"/> allowing the operation to be canceled.</param>
         /// <returns>A list containing all roles available on the server.</returns>

--- a/src/Seq.Api/ResourceGroups/RunningTasksResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/RunningTasksResourceGroup.cs
@@ -1,0 +1,66 @@
+﻿// Copyright Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Seq.Api.Model.Monitoring;
+using Seq.Api.Model.Tasks;
+
+namespace Seq.Api.ResourceGroups
+{
+    /// <summary>
+    /// Inspect and cancel tasks running in the Seq server.
+    /// </summary>
+    public class RunningTasksResourceGroup : ApiResourceGroup
+    {
+        internal RunningTasksResourceGroup (ISeqConnection connection)
+            : base("RunningTasks", connection)
+        {
+        }
+
+        /// <summary>
+        /// Retrieve the task with the given id; throws if the entity does not exist.
+        /// </summary>
+        /// <param name="id">The id of the task.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The task.</returns>
+        public async Task<RunningTaskEntity> FindAsync(string id, CancellationToken cancellationToken = default)
+        {
+            if (id == null) throw new ArgumentNullException(nameof(id));
+            return await GroupGetAsync<RunningTaskEntity>("Item", new Dictionary<string, object> { { "id", id } }, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Retrieve all tasks running on the server.
+        /// </summary>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>A list containing all running tasks.</returns>
+        public async Task<List<RunningTaskEntity>> ListAsync(CancellationToken cancellationToken = default)
+        {
+            return await GroupListAsync<RunningTaskEntity>("Items", null, cancellationToken).ConfigureAwait(false);
+        }
+    
+        /// <summary>
+        /// Request cancellation of a running task. The task must support cancellation; see <see cref="RunningTaskEntity.CanCancel"/>.
+        /// </summary>
+        /// <param name="entity">The task to cancel.</param>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> allowing the cancellation operation itself to be canceled.</param>
+        public async Task RequestCancellationAsync(AlertStateEntity entity, CancellationToken cancellationToken = default)
+        {
+            await Client.DeleteAsync(entity, "Self", entity, cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Seq.Api/ResourceGroups/SettingsResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/SettingsResourceGroup.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -6,6 +20,9 @@ using Seq.Api.Model.Settings;
 
 namespace Seq.Api.ResourceGroups
 {
+    /// <summary>
+    /// Perform operations on system settings.
+    /// </summary>
     public class SettingsResourceGroup : ApiResourceGroup
     {
         internal SettingsResourceGroup(ISeqConnection connection)
@@ -13,42 +30,54 @@ namespace Seq.Api.ResourceGroups
         {
         }
 
+        /// <summary>
+        /// Retrieve the setting with the given id; throws if the entity does not exist.
+        /// </summary>
+        /// <param name="id">The id of the setting.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The setting.</returns>
         public async Task<SettingEntity> FindAsync(string id, CancellationToken cancellationToken = default)
         {
             if (id == null) throw new ArgumentNullException(nameof(id));
             return await GroupGetAsync<SettingEntity>("Item", new Dictionary<string, object> { { "id", id } }, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Retrieve the setting with the given name; throws if the entity does not exist.
+        /// </summary>
+        /// <param name="name">The name of the setting to retrieve. See also <see cref="SettingName"/>.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The setting.</returns>
         public async Task<SettingEntity> FindNamedAsync(SettingName name, CancellationToken cancellationToken = default)
         {
             return await GroupGetAsync<SettingEntity>(name.ToString(), cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<SettingEntity> TemplateAsync(CancellationToken cancellationToken = default)
-        {
-            return await GroupGetAsync<SettingEntity>("Template", cancellationToken: cancellationToken).ConfigureAwait(false);
-        }
-
-        public async Task<SettingEntity> AddAsync(SettingEntity entity, CancellationToken cancellationToken = default)
-        {
-            return await Client.PostAsync<SettingEntity, SettingEntity>(entity, "Create", entity, cancellationToken: cancellationToken).ConfigureAwait(false);
-        }
-
-        public async Task RemoveAsync(SettingEntity entity, CancellationToken cancellationToken = default)
-        {
-            await Client.DeleteAsync(entity, "Self", entity, cancellationToken: cancellationToken).ConfigureAwait(false);
-        }
-
+        /// <summary>
+        /// Update an existing setting.
+        /// </summary>
+        /// <param name="entity">The setting to update.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>A task indicating completion.</returns>
         public async Task UpdateAsync(SettingEntity entity, CancellationToken cancellationToken = default)
         {
             await Client.PutAsync(entity, "Self", entity, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Get internal error reporting settings.
+        /// </summary>
+        /// <returns>Internal error reporting settings.</returns>
         public async Task<InternalErrorReportingSettingsPart> GetInternalErrorReportingAsync()
         {
             return await GroupGetAsync<InternalErrorReportingSettingsPart>("InternalErrorReporting").ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Update internal error reporting settings.
+        /// </summary>
+        /// <param name="internalErrorReporting">New internal error reporting settings.</param>
+        /// <returns>A task indicating completion.</returns>
         public async Task UpdateInternalErrorReportingAsync(InternalErrorReportingSettingsPart internalErrorReporting)
         {
             await GroupPutAsync("InternalErrorReporting", internalErrorReporting).ConfigureAwait(false);

--- a/src/Seq.Api/ResourceGroups/SettingsResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/SettingsResourceGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -67,20 +67,22 @@ namespace Seq.Api.ResourceGroups
         /// <summary>
         /// Get internal error reporting settings.
         /// </summary>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
         /// <returns>Internal error reporting settings.</returns>
-        public async Task<InternalErrorReportingSettingsPart> GetInternalErrorReportingAsync()
+        public async Task<InternalErrorReportingSettingsPart> GetInternalErrorReportingAsync(CancellationToken cancellationToken = default)
         {
-            return await GroupGetAsync<InternalErrorReportingSettingsPart>("InternalErrorReporting").ConfigureAwait(false);
+            return await GroupGetAsync<InternalErrorReportingSettingsPart>("InternalErrorReporting", cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
         /// Update internal error reporting settings.
         /// </summary>
         /// <param name="internalErrorReporting">New internal error reporting settings.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
         /// <returns>A task indicating completion.</returns>
-        public async Task UpdateInternalErrorReportingAsync(InternalErrorReportingSettingsPart internalErrorReporting)
+        public async Task UpdateInternalErrorReportingAsync(InternalErrorReportingSettingsPart internalErrorReporting, CancellationToken cancellationToken = default)
         {
-            await GroupPutAsync("InternalErrorReporting", internalErrorReporting).ConfigureAwait(false);
+            await GroupPutAsync("InternalErrorReporting", internalErrorReporting, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/Seq.Api/ResourceGroups/SignalsResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/SignalsResourceGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/ResourceGroups/SignalsResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/SignalsResourceGroup.cs
@@ -1,11 +1,30 @@
-﻿using System;
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Seq.Api.Model;
 using Seq.Api.Model.Signals;
+using Seq.Api.Model.Users;
 
 namespace Seq.Api.ResourceGroups
 {
+    /// <summary>
+    /// Perform operations on signals. A signal is a collection of filters that identifies a subset of the event stream.
+    /// </summary>
     public class SignalsResourceGroup : ApiResourceGroup
     {
         internal SignalsResourceGroup(ISeqConnection connection)
@@ -13,33 +32,69 @@ namespace Seq.Api.ResourceGroups
         {
         }
 
+        /// <summary>
+        /// Retrieve the signal with the given id; throws if the entity does not exist.
+        /// </summary>
+        /// <param name="id">The id of the signal.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The signal.</returns>
         public async Task<SignalEntity> FindAsync(string id, CancellationToken cancellationToken = default)
         {
             if (id == null) throw new ArgumentNullException(nameof(id));
             return await GroupGetAsync<SignalEntity>("Item", new Dictionary<string, object> { { "id", id } }, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Retrieve signals.
+        /// </summary>
+        /// <param name="ownerId">If the id of a <see cref="UserEntity"/> is provided, only signals owned by them will be included in the result; if
+        /// not specified, personal signals for all owners will be listed.</param>
+        /// <param name="shared">If <c>true</c>, shared signals will be included in the result.</param>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>A list containing matching signals.</returns>
         public async Task<List<SignalEntity>> ListAsync(string ownerId = null, bool shared = false, CancellationToken cancellationToken = default)
         {
             var parameters = new Dictionary<string, object> { { "ownerId", ownerId }, { "shared", shared } };
             return await GroupListAsync<SignalEntity>("Items", parameters, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Construct a signal with server defaults pre-initialized.
+        /// </summary>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The unsaved signal.</returns>
         public async Task<SignalEntity> TemplateAsync(CancellationToken cancellationToken = default)
         {
             return await GroupGetAsync<SignalEntity>("Template", cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Add a new signal.
+        /// </summary>
+        /// <param name="entity">The signal to add.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The signal, with server-allocated properties such as <see cref="Entity.Id"/> initialized.</returns>
         public async Task<SignalEntity> AddAsync(SignalEntity entity, CancellationToken cancellationToken = default)
         {
             return await GroupCreateAsync<SignalEntity, SignalEntity>(entity, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
-
+        /// <summary>
+        /// Remove an existing signal.
+        /// </summary>
+        /// <param name="entity">The signal to remove.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>A task indicating completion.</returns>
         public async Task RemoveAsync(SignalEntity entity, CancellationToken cancellationToken = default)
         {
             await Client.DeleteAsync(entity, "Self", entity, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Update an existing signal.
+        /// </summary>
+        /// <param name="entity">The signal to update.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>A task indicating completion.</returns>
         public async Task UpdateAsync(SignalEntity entity, CancellationToken cancellationToken = default)
         {
             await Client.PutAsync(entity, "Self", entity, cancellationToken: cancellationToken).ConfigureAwait(false);

--- a/src/Seq.Api/ResourceGroups/SqlQueriesResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/SqlQueriesResourceGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/ResourceGroups/SqlQueriesResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/SqlQueriesResourceGroup.cs
@@ -1,11 +1,30 @@
-﻿using System;
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Seq.Api.Model;
 using Seq.Api.Model.SqlQueries;
+using Seq.Api.Model.Users;
 
 namespace Seq.Api.ResourceGroups
 {
+    /// <summary>
+    /// Perform operations on saved SQL queries.
+    /// </summary>
     public class SqlQueriesResourceGroup : ApiResourceGroup
     {
         internal SqlQueriesResourceGroup(ISeqConnection connection)
@@ -13,33 +32,70 @@ namespace Seq.Api.ResourceGroups
         {
         }
 
+        /// <summary>
+        /// Retrieve the query with the given id; throws if the entity does not exist.
+        /// </summary>
+        /// <param name="id">The id of the query.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The query.</returns>
         public async Task<SqlQueryEntity> FindAsync(string id, CancellationToken cancellationToken = default)
         {
             if (id == null) throw new ArgumentNullException(nameof(id));
             return await GroupGetAsync<SqlQueryEntity>("Item", new Dictionary<string, object> { { "id", id } }, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Retrieve queries.
+        /// </summary>
+        /// <param name="ownerId">If the id of a <see cref="UserEntity"/> is provided, only queries owned by them will be included in the result; if
+        /// not specified, personal queries for all owners will be listed.</param>
+        /// <param name="shared">If <c>true</c>, shared queries will be included in the result.</param>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>A list containing matching queries.</returns>
         public async Task<List<SqlQueryEntity>> ListAsync(string ownerId = null, bool shared = false, CancellationToken cancellationToken = default)
         {
             var parameters = new Dictionary<string, object> { { "ownerId", ownerId }, { "shared", shared } };
             return await GroupListAsync<SqlQueryEntity>("Items", parameters, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Construct a query with server defaults pre-initialized.
+        /// </summary>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The unsaved query.</returns>
         public async Task<SqlQueryEntity> TemplateAsync(CancellationToken cancellationToken = default)
         {
             return await GroupGetAsync<SqlQueryEntity>("Template", cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Add a new query.
+        /// </summary>
+        /// <param name="entity">The query to add.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The query, with server-allocated properties such as <see cref="Entity.Id"/> initialized.</returns>
         public async Task<SqlQueryEntity> AddAsync(SqlQueryEntity entity, CancellationToken cancellationToken = default)
         {
             return await GroupCreateAsync<SqlQueryEntity, SqlQueryEntity>(entity, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Remove an existing query.
+        /// </summary>
+        /// <param name="entity">The query to remove.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>A task indicating completion.</returns>
         public async Task RemoveAsync(SqlQueryEntity entity, CancellationToken cancellationToken = default)
         {
             await Client.DeleteAsync(entity, "Self", entity, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Update an existing query.
+        /// </summary>
+        /// <param name="entity">The query to update.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>A task indicating completion.</returns>
         public async Task UpdateAsync(SqlQueryEntity entity, CancellationToken cancellationToken = default)
         {
             await Client.PutAsync(entity, "Self", entity, cancellationToken: cancellationToken).ConfigureAwait(false);

--- a/src/Seq.Api/ResourceGroups/UpdatesResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/UpdatesResourceGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/ResourceGroups/UpdatesResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/UpdatesResourceGroup.cs
@@ -1,10 +1,27 @@
-﻿using System.Collections.Generic;
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Seq.Api.Model.Updates;
 
 namespace Seq.Api.ResourceGroups
 {
+    /// <summary>
+    /// Perform operations on known available Seq versions.
+    /// </summary>
     public class UpdatesResourceGroup : ApiResourceGroup
     {
         internal UpdatesResourceGroup(ISeqConnection connection)
@@ -12,6 +29,11 @@ namespace Seq.Api.ResourceGroups
         {
         }
 
+        /// <summary>
+        /// Retrieve available updates.
+        /// </summary>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>A list of available updates.</returns>
         public async Task<List<AvailableUpdateEntity>> ListAsync(CancellationToken cancellationToken = default)
         {
             return await GroupListAsync<AvailableUpdateEntity>("Items", cancellationToken: cancellationToken).ConfigureAwait(false);

--- a/src/Seq.Api/ResourceGroups/UsersResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/UsersResourceGroup.cs
@@ -1,13 +1,31 @@
-﻿using System;
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Seq.Api.Model.Users;
 using System.Linq;
 using System.Threading;
 using Seq.Api.Client;
+using Seq.Api.Model;
 
 namespace Seq.Api.ResourceGroups
 {
+    /// <summary>
+    /// Perform operations on users.
+    /// </summary>
     public class UsersResourceGroup : ApiResourceGroup
     {
         internal UsersResourceGroup(ISeqConnection connection)
@@ -15,42 +33,90 @@ namespace Seq.Api.ResourceGroups
         {
         }
 
+        /// <summary>
+        /// Retrieve the user with the given id; throws if the entity does not exist.
+        /// </summary>
+        /// <param name="id">The id of the user.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The user.</returns>
         public async Task<UserEntity> FindAsync(string id, CancellationToken cancellationToken = default)
         {
             if (id == null) throw new ArgumentNullException(nameof(id));
             return await GroupGetAsync<UserEntity>("Item", new Dictionary<string, object> { { "id", id } }, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Retrieve the current logged-in user.
+        /// </summary>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The user, or <c>null</c> if no user is logged in.</returns>
         public async Task<UserEntity> FindCurrentAsync(CancellationToken cancellationToken = default)
         {
             return await GroupGetAsync<UserEntity>("Current", cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Retrieve users.
+        /// </summary>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>A list containing matching users.</returns>
         public async Task<List<UserEntity>> ListAsync(CancellationToken cancellationToken = default)
         {
             return await GroupListAsync<UserEntity>("Items", cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Construct a user with server defaults pre-initialized.
+        /// </summary>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The unsaved user.</returns>
         public async Task<UserEntity> TemplateAsync(CancellationToken cancellationToken = default)
         {
             return await GroupGetAsync<UserEntity>("Template", cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Add a new user.
+        /// </summary>
+        /// <param name="entity">The user to add.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The user, with server-allocated properties such as <see cref="Entity.Id"/> initialized.</returns>
         public async Task<UserEntity> AddAsync(UserEntity entity, CancellationToken cancellationToken = default)
         {
             return await Client.PostAsync<UserEntity, UserEntity>(entity, "Create", entity, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Remove an existing user.
+        /// </summary>
+        /// <param name="entity">The user to remove.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>A task indicating completion.</returns>
         public async Task RemoveAsync(UserEntity entity, CancellationToken cancellationToken = default)
         {
             await Client.DeleteAsync(entity, "Self", entity, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Update an existing user.
+        /// </summary>
+        /// <param name="entity">The user to update.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>A task indicating completion.</returns>
         public async Task UpdateAsync(UserEntity entity, CancellationToken cancellationToken = default)
         {
             await Client.PutAsync(entity, "Self", entity, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Log in, using the supplied <paramref name="username"/> and <paramref name="password"/>. Only valid when
+        /// Active Directory or username/password authentication is enabled.
+        /// </summary>
+        /// <param name="username">The username to log in with.</param>
+        /// <param name="password">The password to log in with.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The logged-in user.</returns>
+        /// <remarks>Following successful login, other calls through the API client will authenticate as the logged-in user.</remarks>
         public async Task<UserEntity> LoginAsync(string username, string password, CancellationToken cancellationToken = default)
         {
             if (username == null) throw new ArgumentNullException(nameof(username));
@@ -59,16 +125,45 @@ namespace Seq.Api.ResourceGroups
             return await GroupPostAsync<CredentialsPart, UserEntity>("Login", credentials, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Log out the current user.
+        /// </summary>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>A task indicating completion.</returns>
         public async Task LogoutAsync(CancellationToken cancellationToken = default)
         {
             await GroupPostAsync("Logout", new object(), cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Retrieve the search history for the given user. Only allows the current user's search history to be retrieved.
+        /// </summary>
+        /// <param name="entity">The user to retrieve search history for; must be logged in or the owner of the authenticating API key.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The the user's search history.</returns>
         public async Task<SearchHistoryEntity> GetSearchHistoryAsync(UserEntity entity, CancellationToken cancellationToken = default)
         {
             return await Client.GetAsync<SearchHistoryEntity>(entity, "SearchHistory", cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Update a user's search history by adding, removing, or modifying <paramref name="item"/>.
+        /// </summary>
+        /// <param name="entity">The search history for the user.</param>
+        /// <param name="item">The item to modify.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>A task signalling completion.</returns>
+        public async Task UpdateSearchHistoryAsync(SearchHistoryEntity entity, SearchHistoryItemPart item, CancellationToken cancellationToken = default)
+        { 
+            await Client.PostAsync(entity, "Update", item, cancellationToken: cancellationToken);
+        }
+
+        /// <summary>
+        /// Log in, using integrated Windows authentication. Only available when Active Directory authentication is enabled.
+        /// </summary>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The logged-in user.</returns>
+        /// <remarks>Following successful login, other calls through the API client will authenticate as the logged-in user.</remarks>
         public async Task<UserEntity> LoginWindowsIntegratedAsync(CancellationToken cancellationToken = default)
         {
             var providers = await GroupGetAsync<AuthProvidersPart>("AuthenticationProviders", cancellationToken: cancellationToken).ConfigureAwait(false);

--- a/src/Seq.Api/ResourceGroups/UsersResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/UsersResourceGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -83,7 +83,7 @@ namespace Seq.Api.ResourceGroups
         /// <returns>The user, with server-allocated properties such as <see cref="Entity.Id"/> initialized.</returns>
         public async Task<UserEntity> AddAsync(UserEntity entity, CancellationToken cancellationToken = default)
         {
-            return await Client.PostAsync<UserEntity, UserEntity>(entity, "Create", entity, cancellationToken: cancellationToken).ConfigureAwait(false);
+            return await GroupCreateAsync<UserEntity, UserEntity>(entity, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/Seq.Api/ResourceGroups/WorkspacesResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/WorkspacesResourceGroup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/ResourceGroups/WorkspacesResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/WorkspacesResourceGroup.cs
@@ -1,10 +1,30 @@
-﻿using System;
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
+using Seq.Api.Model;
+using Seq.Api.Model.Users;
 using Seq.Api.Model.Workspaces;
 
 namespace Seq.Api.ResourceGroups
 {
+    /// <summary>
+    /// Perform operations on workspaces.
+    /// </summary>
     public class WorkspacesResourceGroup : ApiResourceGroup
     {
         internal WorkspacesResourceGroup(ISeqConnection connection)
@@ -12,36 +32,73 @@ namespace Seq.Api.ResourceGroups
         {
         }
 
-        public async Task<WorkspaceEntity> FindAsync(string id)
+        /// <summary>
+        /// Retrieve the dashboard with the given id; throws if the entity does not exist.
+        /// </summary>
+        /// <param name="id">The id of the dashboard.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The dashboard.</returns>
+        public async Task<WorkspaceEntity> FindAsync(string id, CancellationToken cancellationToken = default)
         {
             if (id == null) throw new ArgumentNullException(nameof(id));
-            return await GroupGetAsync<WorkspaceEntity>("Item", new Dictionary<string, object> { { "id", id } }).ConfigureAwait(false);
+            return await GroupGetAsync<WorkspaceEntity>("Item", new Dictionary<string, object> { { "id", id } }, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<List<WorkspaceEntity>> ListAsync(string ownerId = null, bool shared = false)
+        /// <summary>
+        /// Retrieve workspaces.
+        /// </summary>
+        /// <param name="ownerId">If the id of a <see cref="UserEntity"/> is provided, only workspaces owned by them will be included in the result; if
+        /// not specified, personal workspaces for all owners will be listed.</param>
+        /// <param name="shared">If <c>true</c>, shared workspaces will be included in the result.</param>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>A list containing matching workspaces.</returns>
+        public async Task<List<WorkspaceEntity>> ListAsync(string ownerId = null, bool shared = false, CancellationToken cancellationToken = default)
         {
             var parameters = new Dictionary<string, object> { { "ownerId", ownerId }, { "shared", shared } };
-            return await GroupListAsync<WorkspaceEntity>("Items", parameters).ConfigureAwait(false);
+            return await GroupListAsync<WorkspaceEntity>("Items", parameters, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<WorkspaceEntity> TemplateAsync()
+        /// <summary>
+        /// Construct a workspace with server defaults pre-initialized.
+        /// </summary>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The unsaved workspace.</returns>
+        public async Task<WorkspaceEntity> TemplateAsync(CancellationToken cancellationToken = default)
         {
-            return await GroupGetAsync<WorkspaceEntity>("Template").ConfigureAwait(false);
+            return await GroupGetAsync<WorkspaceEntity>("Template", cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<WorkspaceEntity> AddAsync(WorkspaceEntity entity)
+        /// <summary>
+        /// Add a new workspace.
+        /// </summary>
+        /// <param name="entity">The workspace to add.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>The workspace, with server-allocated properties such as <see cref="Entity.Id"/> initialized.</returns>
+        public async Task<WorkspaceEntity> AddAsync(WorkspaceEntity entity, CancellationToken cancellationToken = default)
         {
-            return await GroupCreateAsync<WorkspaceEntity, WorkspaceEntity>(entity).ConfigureAwait(false);
+            return await GroupCreateAsync<WorkspaceEntity, WorkspaceEntity>(entity, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task RemoveAsync(WorkspaceEntity entity)
+        /// <summary>
+        /// Remove an existing workspace.
+        /// </summary>
+        /// <param name="entity">The workspace to remove.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>A task indicating completion.</returns>
+        public async Task RemoveAsync(WorkspaceEntity entity, CancellationToken cancellationToken = default)
         {
-            await Client.DeleteAsync(entity, "Self", entity).ConfigureAwait(false);
+            await Client.DeleteAsync(entity, "Self", entity, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task UpdateAsync(WorkspaceEntity entity)
+        /// <summary>
+        /// Update an existing workspace.
+        /// </summary>
+        /// <param name="entity">The workspace to update.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <returns>A task indicating completion.</returns>
+        public async Task UpdateAsync(WorkspaceEntity entity, CancellationToken cancellationToken = default)
         {
-            await Client.PutAsync(entity, "Self", entity).ConfigureAwait(false);
+            await Client.PutAsync(entity, "Self", entity, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/Seq.Api/Seq.Api.csproj
+++ b/src/Seq.Api/Seq.Api.csproj
@@ -1,10 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Client library for the Seq HTTP API.</Description>
     <VersionPrefix>5.1.2</VersionPrefix>
     <Authors>Datalust;Contributors</Authors>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>seq</PackageTags>

--- a/src/Seq.Api/Seq.Api.csproj
+++ b/src/Seq.Api/Seq.Api.csproj
@@ -1,20 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Client library for the Seq HTTP API.</Description>
-    <VersionPrefix>5.1.3</VersionPrefix>
+    <VersionPrefix>2020.1.0</VersionPrefix>
     <Authors>Datalust;Contributors</Authors>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>seq</PackageTags>
-    <Copyright>Copyright © 2014-2019 Datalust Pty Ltd and Contributors</Copyright>
+    <Copyright>Copyright © Datalust Pty Ltd and Contributors</Copyright>
     <PackageIconUrl>https://datalust.co/images/seq-nuget.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/datalust/seq-api</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="Tavis.UriTemplates" Version="1.1.1" />
   </ItemGroup>
 </Project>

--- a/src/Seq.Api/Seq.Api.csproj
+++ b/src/Seq.Api/Seq.Api.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Client library for the Seq HTTP API.</Description>
-    <VersionPrefix>5.1.2</VersionPrefix>
+    <VersionPrefix>5.1.3</VersionPrefix>
     <Authors>Datalust;Contributors</Authors>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/Seq.Api/Seq.Api.csproj
+++ b/src/Seq.Api/Seq.Api.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Client library for the Seq HTTP API.</Description>
-    <VersionPrefix>5.1.1</VersionPrefix>
+    <VersionPrefix>5.1.2</VersionPrefix>
     <Authors>Datalust;Contributors</Authors>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>

--- a/src/Seq.Api/SeqConnection.cs
+++ b/src/Seq.Api/SeqConnection.cs
@@ -39,12 +39,10 @@ namespace Seq.Api
         /// <param name="serverUrl">The base URL of the Seq server.</param>
         /// <param name="apiKey">An API key to use when making requests to the server, if required.</param>
         /// <param name="useDefaultCredentials">Whether default credentials will be sent with HTTP requests; the default is <c>true</c>.</param>
-        /// <param name="requestTimeout">The time to wait before canceling long-running HTTP requests; the default (<c>null</c>) is to use the
-        /// system request timeout, normally 100 seconds. To disable timing out at the client, pass <see cref="Timeout.InfiniteTimeSpan"/>.</param>
-        public SeqConnection(string serverUrl, string apiKey = null, bool useDefaultCredentials = true, TimeSpan? requestTimeout = null)
+        public SeqConnection(string serverUrl, string apiKey = null, bool useDefaultCredentials = true)
         {
             if (serverUrl == null) throw new ArgumentNullException(nameof(serverUrl));
-            Client = new SeqApiClient(serverUrl, apiKey, useDefaultCredentials, requestTimeout);
+            Client = new SeqApiClient(serverUrl, apiKey, useDefaultCredentials);
         }
         
         /// <summary>

--- a/src/Seq.Api/SeqConnection.cs
+++ b/src/Seq.Api/SeqConnection.cs
@@ -142,6 +142,11 @@ namespace Seq.Api
         public UsersResourceGroup Users => new UsersResourceGroup(this);
 
         /// <summary>
+        /// Perform operations on user roles.
+        /// </summary>
+        public RolesResourceGroup Roles => new RolesResourceGroup(this);
+
+        /// <summary>
         /// Perform operations on workspaces.
         /// </summary>
         public WorkspacesResourceGroup Workspaces => new WorkspacesResourceGroup(this);

--- a/src/Seq.Api/SeqConnection.cs
+++ b/src/Seq.Api/SeqConnection.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -75,6 +75,12 @@ namespace Seq.Api
         /// </summary>
         public SeqApiClient Client { get; }
 
+        /// <summary>
+        /// List and administratively remove active alerts. To create/edit/remove alerts in normal
+        /// circumstances, use <see cref="Dashboards"/>.
+        /// </summary>
+        public AlertStateResourceGroup AlertState => new AlertStateResourceGroup(this);
+ 
         /// <summary>
         /// Perform operations on API keys.
         /// </summary>
@@ -181,7 +187,7 @@ namespace Seq.Api
         /// </summary>
         /// <param name="timeout">The maximum amount of time to retry until giving up.</param>
         /// <returns>A task that will complete if the API could be reached, or fault otherwise.</returns>
-        public async Task EnsureConnected(TimeSpan timeout)
+        public async Task EnsureConnectedAsync(TimeSpan timeout)
         {
             var started = DateTime.UtcNow;
             // Fractional milliseconds are lost here, but that's fine.

--- a/src/Seq.Api/SeqConnection.cs
+++ b/src/Seq.Api/SeqConnection.cs
@@ -152,6 +152,11 @@ namespace Seq.Api
         public RolesResourceGroup Roles => new RolesResourceGroup(this);
 
         /// <summary>
+        /// Perform operations on tasks running in the Seq server.
+        /// </summary>
+        public RunningTasksResourceGroup RunningTasks => new RunningTasksResourceGroup(this);
+
+        /// <summary>
         /// Perform operations on system settings.
         /// </summary>
         public SettingsResourceGroup Settings => new SettingsResourceGroup(this);

--- a/src/Seq.Api/SeqConnection.cs
+++ b/src/Seq.Api/SeqConnection.cs
@@ -115,6 +115,11 @@ namespace Seq.Api
         /// Perform operations on retention policies.
         /// </summary>
         public RetentionPoliciesResourceGroup RetentionPolicies => new RetentionPoliciesResourceGroup(this);
+        
+        /// <summary>
+        /// Perform operations on user roles.
+        /// </summary>
+        public RolesResourceGroup Roles => new RolesResourceGroup(this);
 
         /// <summary>
         /// Perform operations on system settings.
@@ -140,11 +145,6 @@ namespace Seq.Api
         /// Perform operations on users.
         /// </summary>
         public UsersResourceGroup Users => new UsersResourceGroup(this);
-
-        /// <summary>
-        /// Perform operations on user roles.
-        /// </summary>
-        public RolesResourceGroup Roles => new RolesResourceGroup(this);
 
         /// <summary>
         /// Perform operations on workspaces.

--- a/src/Seq.Api/SeqConnection.cs
+++ b/src/Seq.Api/SeqConnection.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Threading;

--- a/src/Seq.Api/SeqConnection.cs
+++ b/src/Seq.Api/SeqConnection.cs
@@ -10,58 +10,136 @@ using Seq.Api.ResourceGroups;
 
 namespace Seq.Api
 {
+    /// <summary>
+    /// Exposes high-level (typed) interactions with the Seq API through various resource groups.
+    /// </summary>
     public class SeqConnection : ISeqConnection
     {
         readonly object _sync = new object();
         readonly Dictionary<string, Task<ResourceGroup>> _resourceGroups = new Dictionary<string, Task<ResourceGroup>>();
         Task<RootEntity> _root;
 
-        public SeqConnection(string serverUrl, string apiKey = null, bool useDefaultCredentials = true)
+        /// <summary>
+        /// Construct a <see cref="SeqConnection"/>.
+        /// </summary>
+        /// <param name="serverUrl">The base URL of the Seq server.</param>
+        /// <param name="apiKey">An API key to use when making requests to the server, if required.</param>
+        /// <param name="useDefaultCredentials">Whether default credentials will be sent with HTTP requests; the default is <c>true</c>.</param>
+        /// <param name="requestTimeout">The time to wait before canceling long-running HTTP requests; the default (<c>null</c>) is to use the
+        /// system request timeout, normally 100 seconds. To disable timing out at the client, pass <see cref="Timeout.InfiniteTimeSpan"/>.</param>
+        public SeqConnection(string serverUrl, string apiKey = null, bool useDefaultCredentials = true, TimeSpan? requestTimeout = null)
         {
             if (serverUrl == null) throw new ArgumentNullException(nameof(serverUrl));
-            Client = new SeqApiClient(serverUrl, apiKey, useDefaultCredentials);
+            Client = new SeqApiClient(serverUrl, apiKey, useDefaultCredentials, requestTimeout);
         }
         
+        /// <summary>
+        /// Access the lower-level <see cref="SeqApiClient"/> that can be used for resource-oriented navigation through
+        /// the HTTP API.
+        /// </summary>
         public SeqApiClient Client { get; }
 
+        /// <summary>
+        /// Perform operations on API keys.
+        /// </summary>
         public ApiKeysResourceGroup ApiKeys => new ApiKeysResourceGroup(this);
 
+        /// <summary>
+        /// Perform operations on Seq app instances.
+        /// </summary>
         public AppInstancesResourceGroup AppInstances => new AppInstancesResourceGroup(this);
 
+        /// <summary>
+        /// Perform operations on Seq app packages.
+        /// </summary>
         public AppsResourceGroup Apps => new AppsResourceGroup(this);
 
+        /// <summary>
+        /// Perform operations on backups.
+        /// </summary>
         public BackupsResourceGroup Backups => new BackupsResourceGroup(this);
 
+        /// <summary>
+        /// Perform operations on dashboards.
+        /// </summary>
         public DashboardsResourceGroup Dashboards => new DashboardsResourceGroup(this);
 
+        /// <summary>
+        /// Execute SQL-style queries against the API.
+        /// </summary>
         public DataResourceGroup Data => new DataResourceGroup(this);
 
+        /// <summary>
+        /// Access server diagnostics.
+        /// </summary>
         public DiagnosticsResourceGroup Diagnostics => new DiagnosticsResourceGroup(this);
 
+        /// <summary>
+        /// Read and subscribe to events from the event store.
+        /// </summary>
         public EventsResourceGroup Events => new EventsResourceGroup(this);
 
+        /// <summary>
+        /// Perform operations on queries and filter expressions.
+        /// </summary>
         public ExpressionsResourceGroup Expressions => new ExpressionsResourceGroup(this);
 
+        /// <summary>
+        /// Perform operations on NuGet feeds.
+        /// </summary>
         public FeedsResourceGroup Feeds => new FeedsResourceGroup(this);
 
+        /// <summary>
+        /// Perform operations on the Seq license certificate.
+        /// </summary>
         public LicensesResourceGroup Licenses => new LicensesResourceGroup(this);
 
+        /// <summary>
+        /// Perform operations on permalinked events.
+        /// </summary>
         public PermalinksResourceGroup Permalinks => new PermalinksResourceGroup(this);
 
+        /// <summary>
+        /// Perform operations on retention policies.
+        /// </summary>
         public RetentionPoliciesResourceGroup RetentionPolicies => new RetentionPoliciesResourceGroup(this);
 
+        /// <summary>
+        /// Perform operations on system settings.
+        /// </summary>
         public SettingsResourceGroup Settings => new SettingsResourceGroup(this);
 
+        /// <summary>
+        /// Perform operations on signals.
+        /// </summary>
         public SignalsResourceGroup Signals => new SignalsResourceGroup(this);
 
+        /// <summary>
+        /// Perform operations on saved SQL queries.
+        /// </summary>
         public SqlQueriesResourceGroup SqlQueries => new SqlQueriesResourceGroup(this);
 
+        /// <summary>
+        /// Perform operations on known available Seq versions.
+        /// </summary>
         public UpdatesResourceGroup Updates => new UpdatesResourceGroup(this);
 
+        /// <summary>
+        /// Perform operations on users.
+        /// </summary>
         public UsersResourceGroup Users => new UsersResourceGroup(this);
 
+        /// <summary>
+        /// Perform operations on workspaces.
+        /// </summary>
         public WorkspacesResourceGroup Workspaces => new WorkspacesResourceGroup(this);
 
+        /// <summary>
+        /// Check that the Seq API is available. If the initial attempt fails (i.e. the server is starting up),
+        /// the method will try every 100 milliseconds until <paramref name="timeout"/> is reached.
+        /// </summary>
+        /// <param name="timeout">The maximum amount of time to retry until giving up.</param>
+        /// <returns>A task that will complete if the API could be reached, or fault otherwise.</returns>
         public async Task EnsureConnected(TimeSpan timeout)
         {
             var started = DateTime.UtcNow;
@@ -96,10 +174,10 @@ namespace Seq.Api
             if (!throwOnFailure)
                 return false;
 
-            throw new WebException($"Could not connect to the Seq API endpoint: {(int)statusCode}/{statusCode}.");
+            throw new SeqApiException($"Could not connect to the Seq API endpoint: {(int)statusCode}/{statusCode}.", statusCode);
         }
 
-        public async Task<ResourceGroup> LoadResourceGroupAsync(string name, CancellationToken cancellationToken = default)
+        async Task<ResourceGroup> ISeqConnection.LoadResourceGroupAsync(string name, CancellationToken cancellationToken)
         {
             Task<RootEntity> loadRoot;
             lock (_sync)
@@ -126,7 +204,7 @@ namespace Seq.Api
             return await loadGroup.ConfigureAwait(false);
         }
 
-        async Task<ResourceGroup> GetResourceGroup(RootEntity root, string name, CancellationToken cancellationToken = default)
+        async Task<ResourceGroup> GetResourceGroup(RootEntity root, string name, CancellationToken cancellationToken)
         {
             return await Client.GetAsync<ResourceGroup>(root, name + "Resources", cancellationToken: cancellationToken).ConfigureAwait(false);
         }

--- a/src/Seq.Api/Serialization/LinkCollectionConverter.cs
+++ b/src/Seq.Api/Serialization/LinkCollectionConverter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2019 Datalust and contributors. 
+﻿// Copyright © Datalust and contributors. 
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/Seq.Api/Serialization/LinkCollectionConverter.cs
+++ b/src/Seq.Api/Serialization/LinkCollectionConverter.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright 2014-2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
@@ -6,12 +20,12 @@ using Seq.Api.Model;
 
 namespace Seq.Api.Serialization
 {
-    public class LinkCollectionConverter : JsonConverter
+    class LinkCollectionConverter : JsonConverter
     {
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
             var lc = (LinkCollection)value;
-            var dictionary = lc.ToDictionary(kv => kv.Key, kv => kv.Value.GetUri());
+            var dictionary = lc.ToDictionary(kv => kv.Key, kv => kv.Value.Template);
             serializer.Serialize(writer, dictionary);
         }
 

--- a/src/Seq.Api/Streams/ObservableStream.Unsubscriber.cs
+++ b/src/Seq.Api/Streams/ObservableStream.Unsubscriber.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2016 Datalust; based on code from 
+﻿// Copyright © Datalust; based on code from 
 // Serilog.Sinks.Observable, Copyright 2013-2016 Serilog Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/Seq.Api/Streams/ObservableStream.Unsubscriber.cs
+++ b/src/Seq.Api/Streams/ObservableStream.Unsubscriber.cs
@@ -12,6 +12,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 using System;
 
 namespace Seq.Api.Streams
@@ -25,10 +26,8 @@ namespace Seq.Api.Streams
 
             public Unsubscriber(ObservableStream<T> sink, IObserver<T> observer)
             {
-                if (sink == null) throw new ArgumentNullException(nameof(sink));
-                if (observer == null) throw new ArgumentNullException(nameof(observer));
-                _stream = sink;
-                _observer = observer;
+                _stream = sink ?? throw new ArgumentNullException(nameof(sink));
+                _observer = observer ?? throw new ArgumentNullException(nameof(observer));
             }
 
             public void Dispose()

--- a/src/Seq.Api/Streams/ObservableStream.cs
+++ b/src/Seq.Api/Streams/ObservableStream.cs
@@ -24,8 +24,10 @@ using System.Linq;
 
 namespace Seq.Api.Streams
 {
-    // Some questionable synchronization in this one; probably better to take the Rx dependency
-    // and use the Rx support classes here.
+    /// <summary>
+    /// A stream of values read from a <see cref="WebSocket"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the values.</typeparam>
     public sealed partial class ObservableStream<T> : IObservable<T>, IDisposable
     {
         readonly object _syncRoot = new object();
@@ -42,6 +44,7 @@ namespace Seq.Api.Streams
             _socket = socket ?? throw new ArgumentNullException(nameof(socket));
         }
 
+        /// <inheritdoc/>
         public IDisposable Subscribe(IObserver<T> observer)
         {
             if (observer == null) throw new ArgumentNullException(nameof(observer));
@@ -182,6 +185,7 @@ namespace Seq.Api.Streams
             throw new AggregateException("At least one observer failed to accept the event", exceptions);            
         }
 
+        /// <inheritdoc/>
         public void Dispose()
         {
             lock (_syncRoot)

--- a/test/Seq.Api.Tests/LinkTests.cs
+++ b/test/Seq.Api.Tests/LinkTests.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using Seq.Api.Model;
+using Xunit;
+
+namespace Seq.Api.Tests
+{
+    public class LinkTests
+    {
+        [Fact]
+        public void ALinkWithNoParametersIsLiteral()
+        {
+            const string uri = "https://example.com";
+            var link = new Link(uri);
+            var constructed = link.GetUri();
+            Assert.Equal(uri, constructed);
+        }
+
+        [Fact]
+        public void AParameterizedLinkCanBeConstructed()
+        {
+            const string template = "https://example.com/{name}";
+            var link = new Link(template);
+            var constructed = link.GetUri(new Dictionary<string, object> {["name"] = "test"});
+            Assert.Equal("https://example.com/test", constructed);
+        }
+
+        [Fact]
+        public void InvalidParametersAreDetected()
+        {
+            const string template = "https://example.com";
+            var link = new Link(template);
+            Assert.Throws<ArgumentException>(() => link.GetUri(new Dictionary<string, object> {["name"] = "test"}));
+        }
+    }
+}

--- a/test/Seq.Api.Tests/SeqConnectionTests.cs
+++ b/test/Seq.Api.Tests/SeqConnectionTests.cs
@@ -1,0 +1,20 @@
+﻿using Xunit;
+
+namespace Seq.Api.Tests
+{
+    public class SeqConnectionTests
+    {
+        [Fact]
+        public void WhenConstructedTheHandlerConfigurationCallbackIsCalled()
+        {
+            var callCount = 0;
+
+            using var _ = new SeqConnection("https://test.example.com", null, handler => { 
+                Assert.NotNull(handler);
+                ++callCount;
+            });
+
+            Assert.Equal(1, callCount);
+        }
+    }
+}


### PR DESCRIPTION
 * #80 - support certificate validation callbacks, proxy settings, etc. via `HttpClientHandler`, fix `SeqConnection` disposal (@nblumhardt)
 * #81 and #82 - fix websocket shutdown on recent .NET Core versions; allow app instances, feeds, and users to be created without first calling `TemplateAsync()`; update to Seq 2020.1 API version (changes below) (@nblumhardt)

### 2020.1 API changes

 * `Signal.TaggedProperties` becomes `Signal.Columns` **breaking**
 * `SeqConnection.EnsureConnected()` becomes `EnsureConnectedAsync()`, consistent with the other APIs in this project **breaking**
 * `AppInstanceEntity.InputSignalExpression` renamed to `StreamedSignalExpression` to avoid confusion with _inputs_ **breaking**
 * `AppInstanceEntity.Metrics` split into `ProcessMetrics`, `InputMetrics`, `DiagnosticInputMetrics` and `OutputMetrics` (with corresponding split of `AppInstanceMetricsPart`) **breaking**
 * `RunningTaskPart` moved from _Seq.Api.Model.Diagnostics_ to _RunningTasks_ **breaking**
 * `ApiKeyEntity.InputFilter`, `MinimumLevel`, `UseServerTimestamps` and `AppliedProperties` moved to `ApiKeyEntity.InputSettings` **breaking**
 * `SignalFilterPart` renamed to `DescriptiveFilterPart`, to clarify its use across the API and not only with signals **breaking**
 * Adds `AlertStateEntity` and `SeqConnection.AlertStates`
 * Adds `SettingName.NewUserRoleIds`
 * `SeqApiClient` now accepts `application/vnd.datalust.seq.v8+json`, the media type indicating 2020.1 API support
 * `AppInstanceEntity.InputSettings` added, to support filtering, property tagging, etc.
 * `Entity` carries `ExtensionData` to ease backwards compatibility on the server-side
 * New `SettingName` entries for various OpenID Connect settings, `AuthenticationProvider`, `AutomaticallyProvisionAuthenticatedUsers`, and `AzureADAuthority`; some obsolete settings removed/marked
 * `SeqConnection.RunningTasks` added to support diagnostics and task cancellation
 * `UserEntity` now exposes `AuthenticationProvider` and `AuthenticationProviderUniqueIdentifier`
 * `ApiKeysResourceGroup`, `AppInstancesResourceGroup` and `DiagnosticsResourceGroup` now expose `GetMeasurementTimeseriesAsync()` for 24-hr metric histograms