### PR TITLE
Update to include minor additions in the Seq 2021.4 API

### DIFF
--- a/src/Seq.Api/Model/Diagnostics/Storage/StorageConsumptionPart.cs
+++ b/src/Seq.Api/Model/Diagnostics/Storage/StorageConsumptionPart.cs
@@ -26,6 +26,11 @@ namespace Seq.Api.Model.Diagnostics.Storage
         /// The range of timestamps covered by the result.
         /// </summary>
         public DateTimeRange Range { get; set; }
+        
+        /// <summary>
+        /// The available range of timestamps.
+        /// </summary>
+        public DateTimeRange FullRange { get; set; }
 
         /// <summary>
         /// The duration of the timestamp interval covered by each result.

--- a/src/Seq.Api/Model/Users/AuthProviderInfoPart.cs
+++ b/src/Seq.Api/Model/Users/AuthProviderInfoPart.cs
@@ -34,5 +34,10 @@ namespace Seq.Api.Model.Users
         /// log in using the default provider.
         /// </summary>
         public bool IsAlternative { get; set; }
+
+        /// <summary>
+        /// A template for the URL where the user can log in.
+        /// </summary>
+        public Link Challenge { get; set; }
     }
 }

--- a/src/Seq.Api/Seq.Api.csproj
+++ b/src/Seq.Api/Seq.Api.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Tavis.UriTemplates" Version="1.1.1" />
   </ItemGroup>
   


### PR DESCRIPTION
This includes taking the 13.0.1 update for Newtonsoft.Json. Updating this package has historically been a little lumpy for Seq Apps that depend on it, so we should take extra care to verify functioning of `seqcli app run` etc. when pulling the updated API nupkg into the `seqcli` downstream project.