### PR TITLE
Final API changes for 2022.1

### DIFF
--- a/src/Seq.Api/Client/SeqApiClient.cs
+++ b/src/Seq.Api/Client/SeqApiClient.cs
@@ -48,7 +48,9 @@ namespace Seq.Api.Client
         readonly JsonSerializer _serializer = JsonSerializer.Create(
             new JsonSerializerSettings
             {
-                Converters = { new StringEnumConverter(), new LinkCollectionConverter() }
+                Converters = { new StringEnumConverter(), new LinkCollectionConverter() },
+                DateParseHandling = DateParseHandling.None,
+                FloatParseHandling = FloatParseHandling.Decimal
             });
 
         /// <summary>

--- a/src/Seq.Api/Model/Security/Permission.cs
+++ b/src/Seq.Api/Model/Security/Permission.cs
@@ -56,15 +56,21 @@ namespace Seq.Api.Model.Security
         Setup,
 
         /// <summary>
-        /// Access to settings required for day-to-day operation of Seq, such as users, retention policies, API keys.
+        /// Access to settings that control data ingestion, storage, dashboarding and alerting.
         /// </summary>
         Project,
         
         /// <summary>
         /// Access to settings and features that interact with, or provide access to, the underlying host server,
         /// such as app (plug-in) installation, backup settings, cluster configuration, diagnostics, and features
-        /// relying on outbound network access like package feeds and update checks.
+        /// relying on outbound network access like package feeds and update checks. This permission is required for
+        /// configuration of the authentication provider and related settings.
         /// </summary>
-        System
+        System,
+        
+        /// <summary>
+        /// Create, edit, and delete user accounts, reset local user passwords.
+        /// </summary>
+        Organization
     }
 }

--- a/src/Seq.Api/Model/Security/RoleEntity.cs
+++ b/src/Seq.Api/Model/Security/RoleEntity.cs
@@ -29,6 +29,11 @@ namespace Seq.Api.Model.Security
         /// <summary>
         /// Permissions granted to users in the role.
         /// </summary>
-        public HashSet<Permission> Permissions { get; set; } = new HashSet<Permission>();
+        public HashSet<Permission> Permissions { get; set; } = new();
+        
+        /// <summary>
+        /// Optionally, an extended description of the role.
+        /// </summary>
+        public string Description { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Users/SearchHistoryItemAction.cs
+++ b/src/Seq.Api/Model/Users/SearchHistoryItemAction.cs
@@ -17,7 +17,7 @@ namespace Seq.Api.Model.Users
     /// <summary>
     /// An operation applied to a search history item.
     /// </summary>
-    public enum SearchHistoryItemStatus
+    public enum SearchHistoryItemAction
     {
         /// <summary>
         /// The item was used (make it more recent).
@@ -28,10 +28,10 @@ namespace Seq.Api.Model.Users
         /// The item has been pinned.
         /// </summary>
         Pinned,
-
+        
         /// <summary>
-        /// The item has been un-pinned.
+        /// The item has been unpinned.
         /// </summary>
-        Forgotten
+        Unpinned
     }
 }

--- a/src/Seq.Api/Model/Users/SearchHistoryItemPart.cs
+++ b/src/Seq.Api/Model/Users/SearchHistoryItemPart.cs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// ReSharper disable ClassNeverInstantiated.Global
+
 namespace Seq.Api.Model.Users
 {
     /// <summary>
@@ -20,13 +22,13 @@ namespace Seq.Api.Model.Users
     public class SearchHistoryItemPart
     {
         /// <summary>
-        /// The filter entered by the user into the filter bar.
+        /// The search or query entered by the user into the search bar.
         /// </summary>
         public string Search { get; set; }
 
         /// <summary>
         /// Status to apply to the search history item.
         /// </summary>
-        public SearchHistoryItemStatus Status { get; set; }
+        public SearchHistoryItemAction Action { get; set; }
     }
 }


### PR DESCRIPTION
 * Don't convert date-looking strings to `DateTime` when deserializing untyped JSON values - this prevents unpredictable behavior unpredictable when reading query results etc.
 * Use `decimal` when deserializing numbers in untyped JSON data - this is more accurate because Seq's internal numeric representation is `decimal`
 * Add `Permission.Organization` - part of finalization of the "`System` Permission" RFC
 * Expose a text description of user roles
 * Update the API for user search history tracking
