### PR TITLE
Updates for Seq 2023.4

### DIFF
--- a/src/Seq.Api/Model/Alerting/AlertOccurrencePart.cs
+++ b/src/Seq.Api/Model/Alerting/AlertOccurrencePart.cs
@@ -19,7 +19,7 @@ namespace Seq.Api.Model.Alerting
         /// <summary>
         /// The time grouping that triggered the alert.
         /// </summary>
-        public DateTimeRange DetectedOverRange { get; set; }
+        public DateTimeRangePart DetectedOverRange { get; set; }
 
         /// <summary>
         /// The level of notifications sent for this instance.

--- a/src/Seq.Api/Model/Alerting/AlertOccurrenceRangePart.cs
+++ b/src/Seq.Api/Model/Alerting/AlertOccurrenceRangePart.cs
@@ -11,6 +11,6 @@ namespace Seq.Api.Model.Alerting
         /// <summary>
         /// The time grouping that triggered the alert.
         /// </summary>
-        public DateTimeRange DetectedOverRange { get; set; }
+        public DateTimeRangePart DetectedOverRange { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Cluster/ClusterNodeEntity.cs
+++ b/src/Seq.Api/Model/Cluster/ClusterNodeEntity.cs
@@ -43,6 +43,21 @@ namespace Seq.Api.Model.Cluster
         /// The time since the node's last completed sync operation.
         /// </summary>
         public double? MillisecondsSinceLastSync { get; set; }
+        
+        /// <summary>
+        /// The time since the follower's active sync was started.
+        /// </summary>
+        public double? MillisecondsSinceActiveSync { get; set; }
+        
+        /// <summary>
+        /// The total number of operations in the active sync.
+        /// </summary>
+        public int? TotalActiveOps { get; set;  }
+
+        /// <summary>
+        /// The remaining number of operations in the active sync.
+        /// </summary>
+        public int? RemainingActiveOps { get; set; }
 
         /// <summary>
         /// An informational description of the node's current state, or <c langword="null">null</c> if no additional

--- a/src/Seq.Api/Model/Diagnostics/Storage/StorageConsumptionPart.cs
+++ b/src/Seq.Api/Model/Diagnostics/Storage/StorageConsumptionPart.cs
@@ -25,12 +25,12 @@ namespace Seq.Api.Model.Diagnostics.Storage
         /// <summary>
         /// The range of timestamps covered by the result.
         /// </summary>
-        public DateTimeRange Range { get; set; }
+        public DateTimeRangePart Range { get; set; }
         
         /// <summary>
         /// The available range of timestamps.
         /// </summary>
-        public DateTimeRange FullRange { get; set; }
+        public DateTimeRangePart FullRange { get; set; }
 
         /// <summary>
         /// The duration of the timestamp interval covered by each result.

--- a/src/Seq.Api/Model/Events/EventEntity.cs
+++ b/src/Seq.Api/Model/Events/EventEntity.cs
@@ -62,5 +62,24 @@ namespace Seq.Api.Model.Events
         /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string RenderedMessage { get; set; }
+        
+        /// <summary>
+        /// A trace id associated with the event, if any.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string TraceId { get; set; }
+
+        /// <summary>
+        /// A span id associated with the event, if any.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string SpanId { get; set; }
+
+        /// <summary>
+        /// A collection of properties describing the origin of the event, if any. These correspond to resource
+        /// attributes in the OpenTelemetry spec.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public List<EventPropertyPart> Resource { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Shared/DateTimeRange.cs
+++ b/src/Seq.Api/Model/Shared/DateTimeRange.cs
@@ -5,7 +5,7 @@ namespace Seq.Api.Model.Shared
     /// <summary>
     /// A range represented by a start and end <see cref="DateTime"/>.
     /// </summary>
-    public readonly struct DateTimeRange
+    public readonly struct DateTimeRangePart
     {
         /// <summary>
         /// The (inclusive) start of the range.
@@ -18,11 +18,11 @@ namespace Seq.Api.Model.Shared
         public DateTime End { get; }
 
         /// <summary>
-        /// Construct a <see cref="DateTimeRange"/>.
+        /// Construct a <see cref="DateTimeRangePart"/>.
         /// </summary>
         /// <param name="start">The (inclusive) start of the range.</param>
         /// <param name="end">The (exclusive) end of the range.</param>
-        public DateTimeRange(DateTime start, DateTime end)
+        public DateTimeRangePart(DateTime start, DateTime end)
         {
             Start = start;
             End = end;

--- a/src/Seq.Api/ResourceGroups/ApiKeysResourceGroup.cs
+++ b/src/Seq.Api/ResourceGroups/ApiKeysResourceGroup.cs
@@ -121,5 +121,17 @@ namespace Seq.Api.ResourceGroups
             var parameters = new Dictionary<string, object>{ ["id"] = entity.Id, ["measurement"] = measurement };
             return await GroupGetAsync<MeasurementTimeseriesPart>("Metric", parameters, cancellationToken);
         }
+
+        /// <summary>
+        /// Retrieve a detailed metric for all API keys.
+        /// </summary>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> allowing the operation to be canceled.</param>
+        /// <param name="measurement">The measurement to get.</param>
+        /// <returns></returns>
+        public async Task<Dictionary<string, MeasurementTimeseriesPart>> GetAllMeasurementTimeseriesAsync(string measurement, CancellationToken cancellationToken = default)
+        {
+            var parameters = new Dictionary<string, object>{ ["measurement"] = measurement };
+            return await GroupGetAsync<Dictionary<string, MeasurementTimeseriesPart>>("Metrics", parameters, cancellationToken);
+        }
     }
 }

--- a/src/Seq.Api/Seq.Api.csproj
+++ b/src/Seq.Api/Seq.Api.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Client library for the Seq HTTP API.</Description>
-    <VersionPrefix>2023.3.1</VersionPrefix>
+    <VersionPrefix>2023.1.2</VersionPrefix>
     <Authors>Datalust;Contributors</Authors>
     <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -12,6 +12,10 @@
     <PackageProjectUrl>https://github.com/datalust/seq-api</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <LangVersion>9</LangVersion>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+    <DefineConstants>$(DefineConstants);SOCKETS_HTTP_HANDLER</DefineConstants>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Seq.Api/SeqConnection.cs
+++ b/src/Seq.Api/SeqConnection.cs
@@ -41,7 +41,7 @@ namespace Seq.Api
         /// <param name="serverUrl">The base URL of the Seq server.</param>
         /// <param name="apiKey">An API key to use when making requests to the server, if required.</param>
         /// <param name="useDefaultCredentials">Whether default credentials will be sent with HTTP requests; the default is <c>true</c>.</param>
-        [Obsolete("Prefer `SeqConnection(serverUrl, apiKey, handler => handler.UseDefaultCredentials = true)` instead."), EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Prefer `SeqConnection(serverUrl, apiKey, createHttpMessageHandler)` instead."), EditorBrowsable(EditorBrowsableState.Never)]
         public SeqConnection(string serverUrl, string apiKey, bool useDefaultCredentials)
         {
             if (serverUrl == null) throw new ArgumentNullException(nameof(serverUrl));
@@ -55,10 +55,24 @@ namespace Seq.Api
         /// <param name="apiKey">An API key to use when making requests to the server, if required.</param>
         /// <param name="configureHttpClientHandler">An optional callback to configure the <see cref="HttpClientHandler"/> used when making HTTP requests
         /// to the Seq API.</param>
-        public SeqConnection(string serverUrl, string apiKey = null, Action<HttpClientHandler> configureHttpClientHandler = null)
+        [Obsolete("Prefer `SeqConnection(serverUrl, apiKey, createHttpMessageHandler)` instead."), EditorBrowsable(EditorBrowsableState.Never)]
+        public SeqConnection(string serverUrl, string apiKey, Action<HttpClientHandler> configureHttpClientHandler)
         {
             if (serverUrl == null) throw new ArgumentNullException(nameof(serverUrl));
             Client = new SeqApiClient(serverUrl, apiKey, configureHttpClientHandler);
+        }
+
+        /// <summary>
+        /// Construct a <see cref="SeqConnection"/>.
+        /// </summary>
+        /// <param name="serverUrl">The base URL of the Seq server.</param>
+        /// <param name="apiKey">An API key to use when making requests to the server, if required.</param>
+        /// <param name="createHttpMessageHandler">An optional callback to construct the HTTP message handler used when making requests
+        /// to the Seq API. The callback receives a <see cref="CookieContainer"/> that is shared with WebSocket requests made by the client.</param>
+        public SeqConnection(string serverUrl, string apiKey = null, Func<CookieContainer, HttpMessageHandler> createHttpMessageHandler = null)
+        {
+            if (serverUrl == null) throw new ArgumentNullException(nameof(serverUrl));
+            Client = new SeqApiClient(serverUrl, apiKey, createHttpMessageHandler);
         }
         
         /// <summary>


### PR DESCRIPTION
 * Default to `SocketsHttpHandler` on all platforms
 * New `SeqConnection(string, string, Func<CookieContainer, HttpMessageHandler>)` to allow handler implementation selection
 * Rename `DateTimeRange` to `DateTimeRangePart` in line with other API "DTO" types
 * Add `SeqConnection.ApiKeys.GetAllMeasurementTimeseriesAsync()` for bulk API key metrics