### PR TITLE
Newtonsoft.Json -> System.Text.Json

### DIFF
--- a/example/SeqTail/Program.cs
+++ b/example/SeqTail/Program.cs
@@ -6,7 +6,7 @@ using Serilog;
 using System.Reactive.Linq;
 using Serilog.Formatting.Compact.Reader;
 using System.Threading;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
 
 const string usage = @"seq-tail: watch a Seq query from your console.
 
@@ -67,7 +67,7 @@ static async Task Run(string server, string? apiKey, string? filter, Cancellatio
         strict = converted.StrictExpression;
     }
 
-    using var stream = await connection.Events.StreamAsync<JObject>(filter: strict);
+    using var stream = await connection.Events.StreamAsync<JsonElement>(filter: strict);
     var subscription = stream
         .Select(LogEventReader.ReadFromJObject)
         .Subscribe(Log.Write, cancel.Cancel);

--- a/example/SeqTail/SeqTail.csproj
+++ b/example/SeqTail/SeqTail.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="docopt.net" Version="0.8.1" />
-    <PackageReference Include="Serilog.Formatting.Compact.Reader" Version="2.0.0" />
+    <PackageReference Include="Serilog.Formatting.Compact.Reader" Version="3.0.0-dev-local" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
     <PackageReference Include="System.Reactive" Version="6.0.0" />
   </ItemGroup>

--- a/src/Seq.Api/Model/AppInstances/AppInstanceEntity.cs
+++ b/src/Seq.Api/Model/AppInstances/AppInstanceEntity.cs
@@ -14,7 +14,7 @@
 
 using System;
 using System.Collections.Generic;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using Seq.Api.Model.Apps;
 using Seq.Api.Model.Inputs;
 using Seq.Api.Model.Signals;
@@ -122,57 +122,57 @@ namespace Seq.Api.Model.AppInstances
         /// <summary>
         /// Settings that control how events are ingested through the app.
         /// </summary>
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public InputSettingsPart? InputSettings { get; set; }
 
         /// <summary>
         /// Metrics describing the state and activity of the app process.
         /// </summary>
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public AppInstanceProcessMetricsPart? ProcessMetrics { get; set; }
         
         /// <summary>
         /// Information about ingestion activity through this app.
         /// </summary>
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public InputMetricsPart? InputMetrics { get; set; }
 
         /// <summary>
         /// Information about the app's diagnostic input.
         /// </summary>
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public InputMetricsPart? DiagnosticInputMetrics { get; set; }
 
         /// <summary>
         /// Information about events output through the app.
         /// </summary>
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public AppInstanceOutputMetricsPart? OutputMetrics { get; set; }
         
         /// <summary>
         /// Obsolete.
         /// </summary>
         [Obsolete("Use !AcceptStreamedEvents instead.")]
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public bool? IsManualInputOnly { get; set; }
 
         /// <summary>
         /// Obsolete.
         /// </summary>
         [Obsolete("Use !AcceptDirectInvocation instead.")]
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public bool? DisallowManualInput { get; set; }
 
         /// <summary>
         /// The name of the app.
         /// </summary>
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string? AppName { get; set; }
 
         /// <summary>
         /// If <c>true</c>, then the app is able to write events to the log.
         /// </summary>
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public bool? IsInput { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Data/QueryResultPart.cs
+++ b/src/Seq.Api/Model/Data/QueryResultPart.cs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 using System.Collections.Generic;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Seq.Api.Model.Data
 {
@@ -37,49 +37,49 @@ namespace Seq.Api.Model.Data
         /// <summary>
         /// Result rows.
         /// </summary>
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public object[][] Rows { get; set; }
 
         /// <summary>
         /// Result time slices.
         /// </summary>
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public TimeSlicePart[] Slices { get; set; }
 
         /// <summary>
         /// Result timeseries.
         /// </summary>
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public TimeseriesPart[] Series { get; set; }
         
         /// <summary>
         /// Result variables.
         /// </summary>
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public Dictionary<string, object> Variables { get; set; }
 
         /// <summary>
         /// On error only, a description of the error.
         /// </summary>
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string Error { get; set; }
 
         /// <summary>
         /// Reasons for the <see cref="Error"/>.
         /// </summary>
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string[] Reasons { get; set; }
 
         /// <summary>
         /// A corrected version of the query, if one could be suggested.
         /// </summary>
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string Suggestion { get; set; }
 
         /// <summary>
         /// Execution statistics.
         /// </summary>
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public QueryExecutionStatisticsPart Statistics { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Entity.cs
+++ b/src/Seq.Api/Model/Entity.cs
@@ -14,8 +14,8 @@
 
 using System;
 using System.Collections.Generic;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Seq.Api.Model
 {
@@ -50,8 +50,8 @@ namespace Seq.Api.Model
         /// <summary>
         /// Facilitates backwards compatibility in the Seq server. Should not be used by consumers/clients.
         /// </summary>
-        [JsonExtensionData, JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [JsonExtensionData, JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         [Obsolete("Facilitates backwards compatibility in the Seq server. Should not be used by consumers/clients.")]
-        public Dictionary<string, JToken> ExtensionData { get; set; }
+        public Dictionary<string, JsonElement> ExtensionData { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Events/EventEntity.cs
+++ b/src/Seq.Api/Model/Events/EventEntity.cs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 using System.Collections.Generic;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using Seq.Api.Model.Shared;
 
 // ReSharper disable UnusedAutoPropertyAccessor.Global
@@ -48,38 +48,38 @@ namespace Seq.Api.Model.Events
         /// <summary>
         /// A level associated with an event; <c>null</c> may indicate that the event is informational.
         /// </summary>
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string Level { get; set; }
 
         /// <summary>
         /// An exception, stack trace/backtrace associated with the event.
         /// </summary>
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string Exception { get; set; }
 
         /// <summary>
         /// If requested, a pre-rendered version of the templated event message.
         /// </summary>
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string RenderedMessage { get; set; }
         
         /// <summary>
         /// A trace id associated with the event, if any.
         /// </summary>
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string TraceId { get; set; }
 
         /// <summary>
         /// A span id associated with the event, if any.
         /// </summary>
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string SpanId { get; set; }
 
         /// <summary>
         /// A collection of properties describing the origin of the event, if any. These correspond to resource
         /// attributes in the OpenTelemetry spec.
         /// </summary>
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public List<EventPropertyPart> Resource { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Events/MessageTemplateTokenPart.cs
+++ b/src/Seq.Api/Model/Events/MessageTemplateTokenPart.cs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Seq.Api.Model.Events
 {
@@ -24,25 +24,25 @@ namespace Seq.Api.Model.Events
         /// <summary>
         /// Plain text, if the token is a text token.
         /// </summary>
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string Text { get; set; }
 
         /// <summary>
         /// The name of the property to be rendered in place of the token, if a property token.
         /// </summary>
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string PropertyName { get; set; }
 
         /// <summary>
         /// The raw source text from the message template (provided for both text and property tokens).
         /// </summary>
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string RawText { get; set; }
 
         /// <summary>
         /// A pre-formatted value, if the token carries language-specific formatting directives.
         /// </summary>
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string FormattedValue { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Inputs/ApiKeyEntity.cs
+++ b/src/Seq.Api/Model/Inputs/ApiKeyEntity.cs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 using System.Collections.Generic;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using Seq.Api.Model.Security;
 
 namespace Seq.Api.Model.Inputs
@@ -68,7 +68,7 @@ namespace Seq.Api.Model.Inputs
         /// <summary>
         /// Information about the ingestion activity using this API key.
         /// </summary>
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public InputMetricsPart InputMetrics { get; set; } = new InputMetricsPart();
     }
 }

--- a/src/Seq.Api/Model/LinkCollection.cs
+++ b/src/Seq.Api/Model/LinkCollection.cs
@@ -14,7 +14,7 @@
 
 using System;
 using System.Collections.Generic;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using Seq.Api.Serialization;
 
 namespace Seq.Api.Model

--- a/src/Seq.Api/Model/Permalinks/PermalinkEntity.cs
+++ b/src/Seq.Api/Model/Permalinks/PermalinkEntity.cs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 using System;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using Seq.Api.Model.Events;
 using Seq.Api.ResourceGroups;
 
@@ -49,7 +49,7 @@ namespace Seq.Api.Model.Permalinks
         /// The event itself. Only populated when explicitly requested from the API.
         /// See <see cref="PermalinksResourceGroup.FindAsync"/>.
         /// </summary>
-        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public EventEntity Event { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Retention/RetentionPolicyEntity.cs
+++ b/src/Seq.Api/Model/Retention/RetentionPolicyEntity.cs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 using System;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using Seq.Api.Model.Signals;
 
 namespace Seq.Api.Model.Retention
@@ -40,7 +40,7 @@ namespace Seq.Api.Model.Retention
         /// Obsolete.
         /// </summary>
         [Obsolete("Replaced by RemovedSignalExpression."),
-         JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+         JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string SignalId { get; set; }
     }
 }

--- a/src/Seq.Api/Model/Root/RootEntity.cs
+++ b/src/Seq.Api/Model/Root/RootEntity.cs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 using System.Collections.Generic;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Seq.Api.Model.Root
 {
@@ -49,7 +49,7 @@ namespace Seq.Api.Model.Root
         /// A list of non-default features enabled on this server. Normally, <c langword="null">null</c> unless
         /// an administrator has explicitly opted-into alpha or beta-level features.
         /// </summary>
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public List<string> EnabledFeatures { get; set; }
 
         /// <summary>

--- a/src/Seq.Api/Model/Signals/SignalEntity.cs
+++ b/src/Seq.Api/Model/Signals/SignalEntity.cs
@@ -14,7 +14,7 @@
 
 using System;
 using System.Collections.Generic;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using Seq.Api.Model.Security;
 using Seq.Api.Model.Shared;
 
@@ -60,7 +60,7 @@ namespace Seq.Api.Model.Signals
         /// </summary>
         // ReSharper disable once UnusedMember.Global
         [Obsolete("This member has been renamed `IsProtected` to better reflect its purpose.")]
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public bool? IsRestricted { get; set; }
 
         /// <summary>

--- a/src/Seq.Api/Model/Signals/SignalExpressionPart.cs
+++ b/src/Seq.Api/Model/Signals/SignalExpressionPart.cs
@@ -15,7 +15,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
+
 
 namespace Seq.Api.Model.Signals
 {
@@ -35,21 +36,21 @@ namespace Seq.Api.Model.Signals
         /// When <see cref="Kind"/> is <see cref="SignalExpressionKind.Signal"/>, the id of the
         /// signal represented by this expression node.
         /// </summary>
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string SignalId { get; set; }
 
         /// <summary>
         /// When <see cref="Kind"/> is <see cref="SignalExpressionKind.Intersection"/> or
         /// <see cref="SignalExpressionKind.Union"/>, the left side of the operation.
         /// </summary>
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public SignalExpressionPart Left { get; set; }
 
         /// <summary>
         /// When <see cref="Kind"/> is <see cref="SignalExpressionKind.Intersection"/> or
         /// <see cref="SignalExpressionKind.Union"/>, the right side of the operation.
         /// </summary>
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public SignalExpressionPart Right { get; set; }
 
         /// <summary>

--- a/src/Seq.Api/Model/Users/UserEntity.cs
+++ b/src/Seq.Api/Model/Users/UserEntity.cs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 using System.Collections.Generic;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using Seq.Api.Model.Shared;
 using Seq.Api.Model.Signals;
 
@@ -48,14 +48,14 @@ namespace Seq.Api.Model.Users
         /// <summary>
         /// If changing password, the new password for the user.
         /// </summary>
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string NewPassword { get; set; }
 
         /// <summary>
         /// A filter that is applied to searches and queries instigated by
         /// the user.
         /// </summary>
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public DescriptiveFilterPart ViewFilter { get; set; }
 
         /// <summary>
@@ -63,7 +63,7 @@ namespace Seq.Api.Model.Users
         /// changing their password. Recommended when administratively assigning
         /// a password for the user.
         /// </summary>
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public bool MustChangePassword { get; set; }
 
         /// <summary>
@@ -78,14 +78,14 @@ namespace Seq.Api.Model.Users
         /// user may need to be unlinked from an existing provider so that login can proceed through
         /// the new provider.
         /// </summary>
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string AuthenticationProvider { get; set; }
 
         /// <summary>
         /// The unique identifier that links the identity provided by the authentication provider
         /// with the Seq user.
         /// </summary>
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public string AuthenticationProviderUniqueIdentifier { get; set; }
     }
 }

--- a/src/Seq.Api/Seq.Api.csproj
+++ b/src/Seq.Api/Seq.Api.csproj
@@ -19,11 +19,12 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <!--<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />-->
     <PackageReference Include="Tavis.UriTemplates" Version="2.0.0" />
   </ItemGroup>
   
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Text.Json" Version="7.0.3" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
     <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="all">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
First quick and dirty attempt to migrate from `Newtonsoft.Json` to `System.Text.Json` (see #125), strictly related and partially dependent on https://github.com/serilog/serilog-formatting-compact-reader/pull/37

@nblumhardt: Please consider this PR as a reference only! WARNING, WARNING, WARNING!!!!! in this case the only "test" i did was with `SeqQuery` and `SeqTail` tools, and both them **_SEEMS_** to work...

Warn also in this point (this is why AppVeyor fails to build): https://github.com/datalust/seq-api/blob/c7c0bef9ee5684b7a043e0105629045b08fcf48c/example/SeqTail/SeqTail.csproj#L16 where i "redirected" the dependency to my local nuget feed because i want to use `serilog-formatting-compact-reader` with https://github.com/serilog/serilog-formatting-compact-reader/pull/37 applied





